### PR TITLE
small fixes

### DIFF
--- a/journal/send.go
+++ b/journal/send.go
@@ -34,9 +34,6 @@ var conn net.Conn
 func init() {
 	var err error
 	conn, err = net.Dial("unixgram", "/run/systemd/journal/socket")
-	if err != nil {
-		journalError(err.Error())
-	}
 }
 
 // Enabled returns true iff the systemd journal is available for logging


### PR DESCRIPTION
There's a library function to write out ints in binary that I initially missed.  Updated to use that.  Also, I realized that printing an error in the package init when systemd isn't available is not good behavior; that's been removed.
