### PR TITLE
feat(dbus): add non-polling Unit SubState subscription

### DIFF
--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -15,12 +15,21 @@ type Conn struct {
 		jobs map[dbus.ObjectPath]chan string
 		sync.Mutex
 	}
+	subscriber struct {
+		updateCh chan<- *SubStateUpdate
+		errCh    chan<- error
+		sync.Mutex
+		ignore      map[dbus.ObjectPath]int64
+		cleanIgnore int64
+	}
+	dispatch map[string]func(dbus.Signal)
 }
 
 func New() *Conn {
 	c := new(Conn)
 	c.initConnection()
 	c.initJobs()
+	c.initSubscription()
 	c.initDispatch()
 	return c
 }
@@ -48,6 +57,10 @@ func (c *Conn) initConnection() {
 
 	c.sysconn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0,
 		"type='signal',interface='org.freedesktop.systemd1.Manager',member='JobRemoved'")
+	c.sysconn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0,
+		"type='signal',interface='org.freedesktop.systemd1.Manager',member='UnitNew'")
+	c.sysconn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0,
+		"type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged'")
 
 	err = c.sysobj.Call("org.freedesktop.systemd1.Manager.Subscribe", 0).Store()
 	if err != nil {
@@ -67,6 +80,20 @@ func (c *Conn) initDispatch() {
 			switch signal.Name {
 			case "org.freedesktop.systemd1.Manager.JobRemoved":
 				c.jobComplete(signal)
+
+				unitName := signal.Body[2].(string)
+				var unitPath dbus.ObjectPath
+				c.sysobj.Call("GetUnit", 0, unitName).Store(&unitPath)
+				if unitPath != dbus.ObjectPath("") {
+					c.sendSubStateUpdate(unitPath)
+				}
+			case "org.freedesktop.systemd1.Manager.UnitNew":
+				c.sendSubStateUpdate(signal.Body[1].(dbus.ObjectPath))
+			case "org.freedesktop.DBus.Properties.PropertiesChanged":
+				if signal.Body[0].(string) == "org.freedesktop.systemd1.Unit" {
+					// we only care about SubState updates, which are a Unit property
+					c.sendSubStateUpdate(signal.Path)
+				}
 			}
 		}
 	}()

--- a/dbus/subscription.go
+++ b/dbus/subscription.go
@@ -1,8 +1,18 @@
 package dbus
 
 import (
+	"github.com/guelfey/go.dbus"
 	"time"
 )
+
+const (
+	cleanIgnoreInterval = int64(10 * time.Second)
+	ignoreInterval      = int64(30 * time.Millisecond)
+)
+
+func (c *Conn) initSubscription() {
+	c.subscriber.ignore = make(map[dbus.ObjectPath]int64)
+}
 
 // Returns two unbuffered channels which will receive all changed units every
 // @interval@ seconds.  Deleted units are sent as nil.
@@ -54,4 +64,119 @@ func (c *Conn) SubscribeUnitsCustom(interval time.Duration, buffer int, isChange
 	}()
 
 	return statusChan, errChan
+}
+
+type SubStateUpdate struct {
+	UnitName string
+	SubState string
+}
+
+type Error string
+
+func (e Error) Error() string {
+	return string(e)
+}
+
+// SetSubStateSubscriber writes to updateCh when any unit's substate changes.
+// Althrough this writes to updateCh on every state change, the reported state
+// may be more recent than the change that generated it (due to an unavoidable
+// race in the systemd dbus interface).  That is, this method provides a good
+// way to keep a current view of all units' states, but is not guaranteed to
+// show every state transition they go through.  Furthermore, state changes
+// will only be written to the channel with non-blocking writes.  If updateCh
+// is full, it attempts to write an error to errCh; if errCh is full, the error
+// passes silently.
+func (c *Conn) SetSubStateSubscriber(updateCh chan<- *SubStateUpdate, errCh chan<- error) {
+	c.subscriber.Lock()
+	defer c.subscriber.Unlock()
+	c.subscriber.updateCh = updateCh
+	c.subscriber.errCh = errCh
+}
+
+func (c *Conn) sendSubStateUpdate(path dbus.ObjectPath) {
+	c.subscriber.Lock()
+	defer c.subscriber.Unlock()
+	if c.subscriber.updateCh == nil {
+		return
+	}
+
+	if c.shouldIgnore(path) {
+		return
+	}
+
+	info, err := c.getUnitInfo(path)
+	if err != nil {
+		select {
+		case c.subscriber.errCh <- err:
+		default:
+		}
+	}
+
+	name := info["Id"].Value().(string)
+	substate := info["SubState"].Value().(string)
+
+	update := &SubStateUpdate{name, substate}
+	select {
+	case c.subscriber.updateCh <- update:
+	default:
+		select {
+		case c.subscriber.errCh <- Error("update channel full!"):
+		default:
+		}
+	}
+
+	c.updateIgnore(path, info)
+}
+
+func (c *Conn) getUnitInfo(path dbus.ObjectPath) (map[string]dbus.Variant, error) {
+	var err error
+	var props map[string]dbus.Variant
+	obj := c.sysconn.Object("org.freedesktop.systemd1", path)
+	err = obj.Call("GetAll", 0, "org.freedesktop.systemd1.Unit").Store(&props)
+	if err != nil {
+		return nil, err
+	}
+	return props, nil
+}
+
+// The ignore functions work around a wart in the systemd dbus interface.
+// Requesting the properties of an unloaded unit will cause systemd to send a
+// pair of UnitNew/UnitRemoved signals.  Because we need to get a unit's
+// properties on UnitNew (as that's the only indication of a new unit coming up
+// for the first time), we would enter an infinite loop if we did not attempt
+// to detect and ignore these spurious signals.  The signal themselves are
+// indistinguishable from relevant ones, so we (somewhat hackishly) ignore an
+// unloaded unit's signals for a short time after requesting its properties.
+// This means that we will miss e.g. a transient unit being restarted
+// *immediately* upon failure and also a transient unit being started
+// immediately after requesting its status (with systemctl status, for example,
+// because this causes a UnitNew signal to be sent which then causes us to fetch
+// the properties).
+
+func (c *Conn) shouldIgnore(path dbus.ObjectPath) bool {
+	t, ok := c.subscriber.ignore[path]
+	return ok && t >= time.Now().UnixNano()
+}
+
+func (c *Conn) updateIgnore(path dbus.ObjectPath, info map[string]dbus.Variant) {
+	c.cleanIgnore()
+
+	// unit is unloaded - it will trigger bad systemd dbus behavior
+	if info["LoadState"].Value().(string) == "not-found" {
+		c.subscriber.ignore[path] = time.Now().UnixNano() + ignoreInterval
+	}
+}
+
+// without this, ignore would grow unboundedly over time
+func (c *Conn) cleanIgnore() {
+	now := time.Now().UnixNano()
+	if c.subscriber.cleanIgnore < now {
+		c.subscriber.cleanIgnore = now + cleanIgnoreInterval
+
+		for p, t := range c.subscriber.ignore {
+			if t < now {
+				delete(c.subscriber.ignore, p)
+			}
+		}
+	}
 }


### PR DESCRIPTION
Includes a workaround for systemd's suprious UnitNew/UnitRemoved
signals which CAN miss valid signals if they occur at the wrong time.
See comment in subscription.go for details.
