### PR TITLE
Add PropSlice as a valid argument for StartTransientUnit

### DIFF
--- a/dbus/properties.go
+++ b/dbus/properties.go
@@ -209,3 +209,12 @@ func PropPropagatesReloadTo(units ...string) Property {
 func PropRequiresMountsFor(units ...string) Property {
 	return propDependency("RequiresMountsFor", units)
 }
+
+// PropSlice sets the Slice unit property.  See
+// http://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#Slice=
+func PropSlice(slice string) Property {
+	return Property{
+		Name:  "Slice",
+		Value: dbus.MakeVariant(slice),
+	}
+}


### PR DESCRIPTION
Slice allows transient units to be cgroup jailed by name
