### PR TITLE
dbus: Hardcode EXTERNAL auth using the uid to avoid dynamic linking

### DIFF
--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -18,6 +18,8 @@ limitations under the License.
 package dbus
 
 import (
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -73,7 +75,12 @@ func (c *Conn) initConnection() error {
 		return err
 	}
 
-	err = c.sysconn.Auth(nil)
+	// Only use EXTERNAL method, and hardcode the uid (not username)
+	// to avoid a username lookup (which requires a dynamically linked
+	// libc)
+	methods := []dbus.Auth{dbus.AuthExternal(strconv.Itoa(os.Getuid()))}
+
+	err = c.sysconn.Auth(methods)
 	if err != nil {
 		c.sysconn.Close()
 		return err


### PR DESCRIPTION
The default mode of dbusConn.Auth(nil) is to use EXTERNAL and
DBUS_COOKIE_SHA1. This code calls user.Current() which gives this
warning when linking docker:

```
/var/tmp/go-link-mIsVGq/000005.o: In function `mygetpwuid_r':
/usr/local/go/src/pkg/os/user/lookup_unix.go:72: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/var/tmp/go-link-mIsVGq/000005.o: In function `_cgo_bc43c179ae62_Cfunc_mygetpwuid_r':
/usr/local/go/src/pkg/os/user/lookup_unix.go:27: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
Created binary: /go/src/github.com/dotcloud/docker/bundles/0.9.0-dev/binary/docker-0.9.0-dev
```

For the systemd case we use EXTERNAL anyway, which only needs the uid, not
the username. So we set our own list of methods to avoid running
this code.
