### PR TITLE
fix(subscription): Fix handling of Close()

### DIFF
--- a/dbus/subscription.go
+++ b/dbus/subscription.go
@@ -40,7 +40,6 @@ func (c *Conn) Subscribe() error {
 
 	err := c.sysobj.Call("org.freedesktop.systemd1.Manager.Subscribe", 0).Store()
 	if err != nil {
-		c.sysconn.Close()
 		return err
 	}
 
@@ -51,7 +50,6 @@ func (c *Conn) Subscribe() error {
 func (c *Conn) Unsubscribe() error {
 	err := c.sysobj.Call("org.freedesktop.systemd1.Manager.Unsubscribe", 0).Store()
 	if err != nil {
-		c.sysconn.Close()
 		return err
 	}
 
@@ -69,7 +67,11 @@ func (c *Conn) initDispatch() {
 
 	go func() {
 		for {
-			signal := <-ch
+			signal, ok := <-ch
+			if !ok {
+				return
+			}
+
 			switch signal.Name {
 			case "org.freedesktop.systemd1.Manager.JobRemoved":
 				c.jobComplete(signal)


### PR DESCRIPTION
Do not call sysconn.Close outside of dbus.go. The behavior is surprising
and depending on how the error happened sysconn could already be closed,
resulting in a double-close panic.

Gracefully exit the signal goroutine if its channel has been closed.
