### PR TITLE
feat(login1): initial login1 interface

### DIFF
--- a/login1/dbus.go
+++ b/login1/dbus.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2014 CoreOS Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Integration with the systemd logind API.  See http://www.freedesktop.org/wiki/Software/systemd/logind/
+package login1
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/godbus/dbus"
+)
+
+const (
+	dbusInterface = "org.freedesktop.login1.Manager"
+	dbusPath      = "/org/freedesktop/login1"
+)
+
+// Conn is a connection to systemds dbus endpoint.
+type Conn struct {
+	conn   *dbus.Conn
+	object *dbus.Object
+}
+
+// New() establishes a connection to the system bus and authenticates.
+func New() (*Conn, error) {
+	c := new(Conn)
+
+	if err := c.initConnection(); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func (c *Conn) initConnection() error {
+	var err error
+	c.conn, err = dbus.SystemBusPrivate()
+	if err != nil {
+		return err
+	}
+
+	// Only use EXTERNAL method, and hardcode the uid (not username)
+	// to avoid a username lookup (which requires a dynamically linked
+	// libc)
+	methods := []dbus.Auth{dbus.AuthExternal(strconv.Itoa(os.Getuid()))}
+
+	err = c.conn.Auth(methods)
+	if err != nil {
+		c.conn.Close()
+		return err
+	}
+
+	err = c.conn.Hello()
+	if err != nil {
+		c.conn.Close()
+		return err
+	}
+
+	c.object = c.conn.Object("org.freedesktop.login1", dbus.ObjectPath(dbusPath))
+
+	return nil
+}
+
+// Reboot asks logind for a reboot optionally asking for auth.
+func (c *Conn) Reboot(askForAuth bool) {
+	c.object.Call(dbusInterface+".Reboot", 0, askForAuth)
+}

--- a/login1/dbus_test.go
+++ b/login1/dbus_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2014 CoreOS Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package login1
+
+import (
+	"testing"
+)
+
+// TestNew ensures that New() works without errors.
+func TestNew(t *testing.T) {
+	_, err := New()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This is an initial login1 binding that only supports the Reboot() call. It
would be great to write a generator for this.
