### PR TITLE
unit names with _{a-f}{a-f} in them cause dbus to crash

### DIFF
--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -18,6 +18,7 @@ limitations under the License.
 package dbus
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -26,16 +27,39 @@ import (
 	"github.com/godbus/dbus"
 )
 
-const signalBuffer = 100
+const (
+	alpha        = `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`
+	num          = `0123456789`
+	alphanum     = alpha + num
+	signalBuffer = 100
+)
 
-// ObjectPath creates a dbus.ObjectPath using the rules that systemd uses for
-// serializing special characters.
-func ObjectPath(path string) dbus.ObjectPath {
-	path = strings.Replace(path, ".", "_2e", -1)
-	path = strings.Replace(path, "-", "_2d", -1)
-	path = strings.Replace(path, "@", "_40", -1)
+// needsEscape checks whether a byte in a potential dbus ObjectPath needs to be escaped
+func needsEscape(i int, b byte) bool {
+	// Escape everything that is not a-z-A-Z-0-9
+	// Also escape 0-9 if it's the first character
+	return strings.IndexByte(alphanum, b) == -1 ||
+		(i == 0 && strings.IndexByte(num, b) != -1)
+}
 
-	return dbus.ObjectPath(path)
+// PathBusEscape sanitizes a constituent string of a dbus ObjectPath using the
+// rules that systemd uses for serializing special characters.
+func PathBusEscape(path string) string {
+	// Special case the empty string
+	if len(path) == 0 {
+		return "_"
+	}
+	n := []byte{}
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if needsEscape(i, c) {
+			e := fmt.Sprintf("_%x", c)
+			n = append(n, []byte(e)...)
+		} else {
+			n = append(n, c)
+		}
+	}
+	return string(n)
 }
 
 // Conn is a connection to systemd's dbus endpoint.

--- a/dbus/methods.go
+++ b/dbus/methods.go
@@ -149,7 +149,7 @@ func (c *Conn) getProperties(unit string, dbusInterface string) (map[string]inte
 	var err error
 	var props map[string]dbus.Variant
 
-	path := ObjectPath("/org/freedesktop/systemd1/unit/" + unit)
+	path := unitPath(unit)
 	if !path.IsValid() {
 		return nil, errors.New("invalid unit name: " + unit)
 	}
@@ -177,7 +177,7 @@ func (c *Conn) getProperty(unit string, dbusInterface string, propertyName strin
 	var err error
 	var prop dbus.Variant
 
-	path := ObjectPath("/org/freedesktop/systemd1/unit/" + unit)
+	path := unitPath(unit)
 	if !path.IsValid() {
 		return nil, errors.New("invalid unit name: " + unit)
 	}
@@ -399,4 +399,8 @@ type DisableUnitFileChange struct {
 // equivalent to a 'systemctl daemon-reload'.
 func (c *Conn) Reload() error {
 	return c.sysobj.Call("org.freedesktop.systemd1.Manager.Reload", 0).Store()
+}
+
+func unitPath(name string) dbus.ObjectPath {
+	return dbus.ObjectPath("/org/freedesktop/systemd1/unit/" + PathBusEscape(name))
 }


### PR DESCRIPTION
Fun and profit.

go program to reproduce:

``` go
package main

import (
    "fmt"
    "io/ioutil"
    "os"
    "strings"

    "github.com/coreos/go-systemd/dbus"
)

const contents = `[Service]
ExecStart=/bin/true
`

func log(f string, v ...interface{}) {
    msg := fmt.Sprintf(f, v...)
    if !strings.HasSuffix(msg, "\n") {
        msg += "\n"
    }
    fmt.Printf(msg)
}
func die(f string, v ...interface{}) {
    fmt.Fprintf(os.Stderr, f, v...)
    os.Exit(1)
}

func main() {
    if len(os.Args) != 2 {
        die("usage: %s UNIT_NAME\n", os.Args[0])
    }
    name := os.Args[1]
    path := "/tmp/" + name
    sd, err := dbus.New()
    if err != nil {
        die("error initializing dbus connection: %v\n", err)
    } else {
        log("initialized dbus connection")
    }

    if err := ioutil.WriteFile(path, []byte(contents), os.FileMode(0644)); err != nil {
        die("error writing unit: %v\n", err)
    } else {
        log("wrote unit to disk")
    }

    if _, err = sd.LinkUnitFiles([]string{path}, true, true); err != nil {
        die("error linking unit file: %v\n", err)
    } else {
        log("linked runtime unit file")
    }

    if err := sd.Reload(); err != nil {
        die("error reloading systemd: %v\n", err)
    } else {
        log("reloaded systemd")
    }

    if info, err := sd.GetUnitProperties(name); err != nil {
        die("error getting unit properties: %v\n", err)
    } else {
        log("unit properties: %v\n", info)
    }
    os.Exit(0)
}
```

script to test cases:

``` bash
#!/bin/bash

trap "exit" INT

pkill dbus-daemon
for i in - _ a b c d e f g h i j k l m n o p q r s t u w x y z; do 
  for j in - _ a b c d e f g h i j k l m n o p q r s t u w x y z; do 
     name=_${i}${j}.service
     ./go-systemd ${name} &> /dev/null
     if [ $? -ne 0 ]; then
       echo "$name failed!"
       pkill dbus-daemon
       sleep 0.1
     fi
  done
done
```

results:

```
core-01 core # ./break.sh 
_aa.service failed!
_ab.service failed!
_ac.service failed!
_ad.service failed!
_ae.service failed!
_af.service failed!
_ba.service failed!
_bb.service failed!
_bc.service failed!
_bd.service failed!
_be.service failed!
_bf.service failed!
_ca.service failed!
_cb.service failed!
_cc.service failed!
_cd.service failed!
_ce.service failed!
_cf.service failed!
_da.service failed!
_db.service failed!
_dc.service failed!
_dd.service failed!
_de.service failed!
_df.service failed!
_ea.service failed!
_eb.service failed!
_ec.service failed!
_ed.service failed!
_ee.service failed!
_ef.service failed!
_fa.service failed!
_fb.service failed!
_fc.service failed!
_fd.service failed!
_fe.service failed!
_ff.service failed!
```
