### PR TITLE
dbus: fix ResetFailedUnit

### DIFF
--- a/dbus/methods.go
+++ b/dbus/methods.go
@@ -140,8 +140,8 @@ func (c *Conn) KillUnit(name string, signal int32) {
 }
 
 // ResetFailedUnit resets the "failed" state of a specific unit.
-func (c *Conn) ResetFailedUnit(name string) (string, error) {
-	return c.runJob("org.freedesktop.systemd1.Manager.ResetFailedUnit", name)
+func (c *Conn) ResetFailedUnit(name string) error {
+	return c.sysobj.Call("org.freedesktop.systemd1.Manager.ResetFailedUnit", 0, name).Store()
 }
 
 // getProperties takes the unit name and returns all of its dbus object properties, for the given dbus interface


### PR DESCRIPTION
ResetFailedUnit currently triggers the reset properly, but the result is parsed incorrectly if it's treated as a "job". Treating it as a call fixes this.
