### PR TITLE
dbus: add ConnectTo method

### DIFF
--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -82,9 +82,33 @@ type Conn struct {
 
 // New() establishes a connection to the system bus and authenticates.
 func New() (*Conn, error) {
+	var err error
 	c := new(Conn)
+	
+	c.sysconn, err = dbus.SystemBusPrivate()
+	if err != nil {
+		return err
+	}
 
-	if err := c.initConnection(); err != nil {
+	if err = c.initConnection(); err != nil {
+		return nil, err
+	}
+
+	c.initJobs()
+	return c, nil
+}
+
+// ConnectTo() establishes a connection to the given address and authenticates.
+func ConnectTo(address string) (*Conn, error) {
+	var err error
+	c := new(Conn)
+	
+	c.sysconn, err = dbus.Dial(address)
+	if err != nil {
+		return err
+	}
+
+	if err = c.initConnection(); err != nil {
 		return nil, err
 	}
 
@@ -94,11 +118,7 @@ func New() (*Conn, error) {
 
 func (c *Conn) initConnection() error {
 	var err error
-	c.sysconn, err = dbus.SystemBusPrivate()
-	if err != nil {
-		return err
-	}
-
+	
 	// Only use EXTERNAL method, and hardcode the uid (not username)
 	// to avoid a username lookup (which requires a dynamically linked
 	// libc)

--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -84,10 +84,10 @@ type Conn struct {
 func New() (*Conn, error) {
 	var err error
 	c := new(Conn)
-	
+
 	c.sysconn, err = dbus.SystemBusPrivate()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err = c.initConnection(); err != nil {
@@ -102,10 +102,10 @@ func New() (*Conn, error) {
 func ConnectTo(address string) (*Conn, error) {
 	var err error
 	c := new(Conn)
-	
+
 	c.sysconn, err = dbus.Dial(address)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err = c.initConnection(); err != nil {
@@ -118,7 +118,7 @@ func ConnectTo(address string) (*Conn, error) {
 
 func (c *Conn) initConnection() error {
 	var err error
-	
+
 	// Only use EXTERNAL method, and hardcode the uid (not username)
 	// to avoid a username lookup (which requires a dynamically linked
 	// libc)


### PR DESCRIPTION
This adds a ConnectTo method to the dbus part so one can connect to different dbus deamons. My usecase for this is to connect to remote servers via socat and ssh to control systemd.