### PR TITLE
Make systemd running within a docker container register with machinectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Go bindings to systemd. The project has three packages:
 - dbus - for starting/stopping/inspecting running services and units
 - journal - for writing to systemd's logging service, journal
 - unit - for (de)serialization and comparison of unit files
+- machine1 - for registering machines/containers with systemd
 
 Go docs for the entire project are here:
 

--- a/machine1/dbus.go
+++ b/machine1/dbus.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2015 CoreOS Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Integration with the systemd machined API.  See http://www.freedesktop.org/wiki/Software/systemd/machined/
+package machine1
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/godbus/dbus"
+)
+
+const (
+	dbusInterface = "org.freedesktop.machine1.Manager"
+	dbusPath      = "/org/freedesktop/machine1"
+)
+
+// Conn is a connection to systemds dbus endpoint.
+type Conn struct {
+	conn   *dbus.Conn
+	object *dbus.Object
+}
+
+// New() establishes a connection to the system bus and authenticates.
+func New() (*Conn, error) {
+	c := new(Conn)
+
+	if err := c.initConnection(); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func (c *Conn) initConnection() error {
+	var err error
+	c.conn, err = dbus.SystemBusPrivate()
+	if err != nil {
+		return err
+	}
+
+	// Only use EXTERNAL method, and hardcode the uid (not username)
+	// to avoid a username lookup (which requires a dynamically linked
+	// libc)
+	methods := []dbus.Auth{dbus.AuthExternal(strconv.Itoa(os.Getuid()))}
+
+	err = c.conn.Auth(methods)
+	if err != nil {
+		c.conn.Close()
+		return err
+	}
+
+	err = c.conn.Hello()
+	if err != nil {
+		c.conn.Close()
+		return err
+	}
+
+	c.object = c.conn.Object("org.freedesktop.machine1", dbus.ObjectPath(dbusPath))
+
+	return nil
+}
+
+// RegisterMachine registers the container with the systemd-machined
+func (c *Conn) RegisterMachine(name string, id []byte, service string, class string, pid int, root_directory string) error {
+	return c.object.Call(dbusInterface+".RegisterMachine", 0, name, id, service, class, uint32(pid), root_directory).Err
+}

--- a/machine1/dbus_test.go
+++ b/machine1/dbus_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2015 CoreOS Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine1
+
+import (
+	"testing"
+)
+
+// TestNew ensures that New() works without errors.
+func TestNew(t *testing.T) {
+	_, err := New()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
I am working on a patch for docker to have systemd running within a container
log to journald outside of the container.  In order for this to work, the
docker container needs to be registered within machinectl.  This patch
gives go bindings to machinectl in systemd.