### PR TITLE
util: add GetRunningSlice, RunningFromSystemService, CurrentUnitName

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -13,12 +13,145 @@
 // limitations under the License.
 
 // Package util contains utility functions related to systemd that applications
-// can use to check things like whether systemd is running.
+// can use to check things like whether systemd is running.  Note that some of
+// these functions attempt to manually load systemd libraries at runtime rather
+// than linking against them.
 package util
 
+// #cgo LDFLAGS: -ldl
+// #include <stdlib.h>
+// #include <dlfcn.h>
+// #include <sys/types.h>
+//
+// int
+// my_sd_pid_get_owner_uid(void *f, pid_t pid, uid_t *uid)
+// {
+//   int (*sd_pid_get_owner_uid)(pid_t, uid_t *);
+//
+//   sd_pid_get_owner_uid = (int (*)(pid_t, uid_t *))f;
+//   return sd_pid_get_owner_uid(pid, uid);
+// }
+//
+// int
+// my_sd_pid_get_slice(void *f, pid_t pid, char **slice)
+// {
+//   int (*sd_pid_get_slice)(pid_t, char **);
+//
+//   sd_pid_get_slice = (int (*)(pid_t, char **))f;
+//   return sd_pid_get_slice(pid, slice);
+// }
+//
+import "C"
 import (
+	"fmt"
 	"os"
+	"syscall"
+	"unsafe"
 )
+
+// getHandle tries to get a handle to a systemd library (.so), attempting to
+// access it by several different names and returning the first that is
+// successfully opened. Callers are responsible for closing the handler.
+// Returns nil if no library can be found.
+func getHandle() (unsafe.Pointer, string) {
+	for _, name := range []string{
+		// systemd < 209
+		"libsystemd-login.so",
+		"libsystemd-login.so.0",
+
+		// systemd >= 209 merged libsystemd-login into libsystemd proper
+		"libsystemd.so",
+		"libsystemd.so.0",
+	} {
+		libname := C.CString(name)
+		defer C.free(unsafe.Pointer(libname))
+		handle := C.dlopen(libname, C.RTLD_LAZY)
+		if handle != nil {
+			return handle, name
+		}
+	}
+	return nil, ""
+}
+
+// GetRunningSlice attempts to retrieve the name of the systemd slice in which
+// the current process is running.
+func GetRunningSlice() (slice string, err error) {
+	handle, libname := getHandle()
+	if handle == nil {
+		err = fmt.Errorf("error opening libsystemd-login.so")
+		return
+	}
+	defer func() {
+		if r := C.dlclose(handle); r != 0 {
+			err = fmt.Errorf("error closing %v", libname)
+		}
+	}()
+
+	sym := C.CString("sd_pid_get_slice")
+	defer C.free(unsafe.Pointer(sym))
+	sd_pid_get_slice := C.dlsym(handle, sym)
+	if sd_pid_get_slice == nil {
+		err = fmt.Errorf("error resolving sd_pid_get_slice function")
+		return
+	}
+
+	var s string
+	sl := C.CString(s)
+	defer C.free(unsafe.Pointer(sl))
+
+	ret := C.my_sd_pid_get_slice(sd_pid_get_slice, 0, &sl)
+	if ret < 0 {
+		err = fmt.Errorf("error calling sd_pid_get_slice: %v", syscall.Errno(-ret))
+		return
+	}
+
+	slice = C.GoString(sl)
+	return
+}
+
+// RunningFromSystemService detects whether the current process has been invoked
+// from a system service. The condition for this is whether the process is
+// _not_ a user process. User processes are those running in session scopes or
+// under per-user `systemd --user` instances
+func RunningFromSystemService() (ret bool, err error) {
+	handle, libname := getHandle()
+	if handle == nil {
+		// can't open libsystemd so we assume systemd is not
+		// installed and we're not running from a unit file
+		ret = false
+		return
+	}
+	defer func() {
+		if r := C.dlclose(handle); r != 0 {
+			err = fmt.Errorf("error closing %v", libname)
+		}
+	}()
+
+	sym := C.CString("sd_pid_get_owner_uid")
+	defer C.free(unsafe.Pointer(sym))
+	sd_pid_get_owner_uid := C.dlsym(handle, sym)
+	if sd_pid_get_owner_uid == nil {
+		err = fmt.Errorf("error resolving sd_pid_get_owner_uid function")
+		return
+	}
+
+	var uid C.uid_t
+	errno := C.my_sd_pid_get_owner_uid(sd_pid_get_owner_uid, 0, &uid)
+	serrno := syscall.Errno(-errno)
+	// when we're running from a unit file, sd_pid_get_owner_uid returns
+	// ENOENT (systemd <220) or ENXIO (systemd >=220)
+	switch {
+	case errno >= 0:
+		ret = false
+		return
+	case serrno == syscall.ENOENT, serrno == syscall.ENXIO:
+		ret = true
+		return
+	default:
+		err = fmt.Errorf("error calling sd_pid_get_owner_uid: %v", syscall.Errno(-errno))
+		return
+	}
+}
 
 // IsRunningSystemd checks whether the host was booted with systemd as its init
 // system. This functions similar to systemd's `sd_booted(3)`: internally, it


### PR DESCRIPTION
This adds two utility functions which can be used by processes to determine
their context (slice), and whether they are running from a systemd "system"
service.

This is a port of [code in rkt](https://github.com/coreos/rkt/blob/d23669f63644f63c1c5b61ea3c95f90ee9ab66f9/stage1/init/init.go#L399), with a few improvements (correctly freeing CStrings, broader portability for older systemd versions).

To check for whether we're running from a "system service" we use the approach suggested by Lennart (and described [here](https://github.com/coreos/rkt/issues/911#issuecomment-103853978)):

	hence: to detect if something is a system service, the best approach is
	to check if it is not a user process. There are two kinds of user
	processes: those running in session scopes, and those running of the
	per-user systemd --user instance (which is a per-user singleton shared
	by every session of the user). sd_pid_get_owner_uid() can recognize
	session scopes and the systemd --user service, extracts the uid from it
	and returns it. It's hence suitable as a check if something is user
	code or not.

Unfortunately this results in false positives: on CoreOS Linux, where there's no PAM, logging in does not result in a user slice/scope being created, and instead the session runs under `systemd-sshd.slice`:

	core@coreos_production_qemu-633-1-0 ~ $ systemd-cgls |fgrep $PPID -B3
	  ├─system-sshd.slice
	  │ ├─sshd@9-10.0.2.15:22-10.0.2.2:44781.service
	  │ │ ├─18061 sshd: core [priv]
	  │ │ ├─18063 sshd: core@pts/2
	  │ │ ├─18064 -bash
	  │ │ ├─19669 systemd-cgls
	  │ │ └─19670 grep -F 18063 -B3

	core@coreos_production_qemu-633-1-0 ~ $ ./sysd
	slice = system-sshd.slice
	runningFromSystemService = true

compare to a Fedora 20 system where a user scope is created:

	jon@fedora20 ~ $ systemd-cgls | fgrep $PPID -B2
	  │ └─session-452.scope
	  │   ├─2809 sshd: jon [priv]
	  │   ├─2814 sshd: jon@pts/13
	  │   ├─2816 -bash
	  │   ├─2928 systemd-cgls
	  │   └─2929 fgrep --color=auto 2814 -B2
	
	jon@fedora20 ~ $ ./sysd 
	slice = user-1000.slice
	runningFromSystemService = false