### PR TITLE
unit: add NewUnitOption convenience function

### DIFF
--- a/unit/option.go
+++ b/unit/option.go
@@ -24,6 +24,10 @@ type UnitOption struct {
 	Value   string
 }
 
+func NewUnitOption(section, name, value string) *UnitOption {
+	return &UnitOption{Section: section, Name: name, Value: value}
+}
+
 func (uo *UnitOption) String() string {
 	return fmt.Sprintf("{Section: %q, Name: %q, Value: %q}", uo.Section, uo.Name, uo.Value)
 }


### PR DESCRIPTION
This convenience function is used a lot in [rkt/stage1/init/pod.go](https://github.com/coreos/rkt/blob/master/stage1/init/pod.go) and I'd like to reuse it somewhere else.