### PR TITLE
[RFC] unit: pass through line continuations

### DIFF
--- a/unit/deserialize.go
+++ b/unit/deserialize.go
@@ -191,15 +191,15 @@ func (l *lexer) lexOptionValueFunc(section, name string) lexStep {
 				return nil, err
 			}
 
+			partial.Write(line)
+
 			// lack of continuation means this value has been exhausted
 			idx := bytes.LastIndex(line, []byte{'\\'})
 			if idx == -1 || idx != (len(line)-1) {
-				partial.Write(line)
 				break
 			}
 
-			partial.Write(line[0:idx])
-			partial.WriteRune(' ')
+			partial.WriteRune('\n')
 		}
 
 		val := strings.TrimSpace(partial.String())

--- a/unit/deserialize_test.go
+++ b/unit/deserialize_test.go
@@ -80,14 +80,15 @@ Environment= "FOO=BAR" "BAZ=QUX"
 			},
 		},
 
-		// line continuations respected
+		// line continuations unmodified
 		{
 			[]byte(`[Unit]
 Description= Unnecessarily wrapped \
     words here
 `),
 			[]*UnitOption{
-				&UnitOption{"Unit", "Description", "Unnecessarily wrapped      words here"},
+				&UnitOption{"Unit", "Description", `Unnecessarily wrapped \
+    words here`},
 			},
 		},
 
@@ -119,8 +120,8 @@ Description=Bar\
 Baz
 `),
 			[]*UnitOption{
-				&UnitOption{"Unit", "Description", "Bar # comment alpha"},
-				&UnitOption{"Unit", "Description", "Bar # comment bravo  Baz"},
+				&UnitOption{"Unit", "Description", "Bar\\\n# comment alpha"},
+				&UnitOption{"Unit", "Description", "Bar\\\n# comment bravo \\\nBaz"},
 			},
 		},
 
@@ -180,7 +181,7 @@ Description=Bar`),
 			[]byte(`[Unit]
 Description=Bar \`),
 			[]*UnitOption{
-				&UnitOption{"Unit", "Description", "Bar"},
+				&UnitOption{"Unit", "Description", "Bar \\"},
 			},
 		},
 
@@ -218,7 +219,7 @@ Description= words here `),
 Description= words here \
   `),
 			[]*UnitOption{
-				&UnitOption{"Unit", "Description", "words here"},
+				&UnitOption{"Unit", "Description", "words here \\"},
 			},
 		},
 

--- a/unit/end_to_end_test.go
+++ b/unit/end_to_end_test.go
@@ -1,0 +1,76 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+)
+
+func TestDeserializeAndReserialize(t *testing.T) {
+	tests := []struct {
+		in   string
+		wout string
+	}{
+		{
+			`[Service]
+ExecStart=/bin/bash -c "while true; do echo \"ping\"; sleep 1; done"
+`,
+			`[Service]
+ExecStart=/bin/bash -c "while true; do echo \"ping\"; sleep 1; done"
+`},
+		{
+			`[Unit]
+Description= Unnecessarily wrapped \
+    words here`,
+			`[Unit]
+Description=Unnecessarily wrapped \
+    words here
+`,
+		},
+		{
+			`; comment alpha
+# comment bravo
+[Unit]
+; comment charlie
+# comment delta
+#Description=Foo
+Description=Bar
+; comment echo
+# comment foxtrot
+`,
+			`[Unit]
+Description=Bar
+`},
+	}
+	for i, tt := range tests {
+		ds, err := Deserialize(bytes.NewBufferString(tt.in))
+		if err != nil {
+			t.Errorf("case %d: unexpected error parsing unit: %v", i, err)
+			continue
+		}
+		out, err := ioutil.ReadAll(Serialize(ds))
+		if err != nil {
+			t.Errorf("case %d: unexpected error serializing unit: %v", i, err)
+			continue
+		}
+		if g := string(out); g != tt.wout {
+			t.Errorf("case %d: incorrect output", i)
+			t.Logf("Expected:\n%#v", tt.wout)
+			t.Logf("Actual:\n%#v", g)
+		}
+	}
+}


### PR DESCRIPTION
If a unit file contains line continuations, unit.Deserialize has been
stripping them out. Unfortunately this means it is impossible for
go-systemd users to work around the line length limit in systemd (1) by
splitting a long line into multiple ones, because go-systemd will just
rejoin them into a single, unusable line.

This changes unit.Deserialize to no longer strip out line continuations but
instead preserve them in the relevant options' values

Partial solution for coreos/fleet#992, along with #101

RFC - there are a few ways to approach this, none of which I'm particularly
happy with (in hindsight I think the lexer is a bad idea) - this is an attempt
at a minimally invasive solution.