### PR TITLE
*: expand/enhance test script

### DIFF
--- a/test
+++ b/test
@@ -1,3 +1,73 @@
-#!/bin/sh -e
+#!/bin/bash -e
+#
+# Run all tests
+#   ./test
+#   ./test -v
+#
+# Run tests for one package
+#   PKG=./foo ./test
+#   PKG=bar ./test
+#
 
-go test -v ./...
+# Invoke ./cover for HTML output
+COVER=${COVER:-"-cover"}
+
+PROJ="go-systemd"
+ORG_PATH="github.com/coreos"
+REPO_PATH="${ORG_PATH}/${PROJ}"
+
+# As a convenience, set up a self-contained GOPATH if none set
+if [ -z "$GOPATH" ]; then
+	if [ ! -h gopath/src/${REPO_PATH} ]; then
+		mkdir -p gopath/src/${ORG_PATH}
+		ln -s ../../../.. gopath/src/${REPO_PATH} || exit 255
+	fi
+	export GOPATH=${PWD}/gopath
+	go get -u github.com/godbus/dbus
+fi
+
+TESTABLE="activation login1 machine1 unit"
+FORMATTABLE="$TESTABLE dbus"
+if [ "$EUID" == "0" ]; then
+	# testing actual systemd behaviour requires root
+	TESTABLE="${TESTABLE} dbus"
+fi
+
+
+# user has not provided PKG override
+if [ -z "$PKG" ]; then
+	TEST=$TESTABLE
+	FMT=$FORMATTABLE
+
+# user has provided PKG override
+else
+	# strip out slashes and dots from PKG=./foo/
+	TEST=${PKG//\//}
+	TEST=${TEST//./}
+
+	# only run gofmt on packages provided by user
+	FMT="$TEST"
+fi
+
+# split TEST into an array and prepend REPO_PATH to each local package
+split=(${TEST// / })
+TEST=${split[@]/#/${REPO_PATH}/}
+
+echo "Running tests..."
+go test ${COVER} $@ ${TEST}
+
+echo "Checking gofmt..."
+fmtRes=$(gofmt -l $FMT)
+if [ -n "${fmtRes}" ]; then
+	echo -e "gofmt checking failed:\n${fmtRes}"
+	exit 255
+fi
+
+echo "Checking govet..."
+vetRes=$(go vet $TEST)
+if [ -n "${vetRes}" ]; then
+	echo -e "govet checking failed:\n${vetRes}"
+	exit 255
+fi
+
+echo "Success"


### PR DESCRIPTION
Borrowing from the other common CoreOS test scripts, we now:
- build a self-contained gopath for testing if GOPATH is not set
- run all unit tests
- run actual systemd dbus tests if invoked as root
- run gofmt and go vet across all go source files