### PR TITLE
unit: pass through line continuations (extended)

### DIFF
--- a/unit/deserialize.go
+++ b/unit/deserialize.go
@@ -80,7 +80,7 @@ func (l *lexer) lexSectionName() (lexStep, error) {
 
 func (l *lexer) lexSectionSuffixFunc(section string) lexStep {
 	return func() (lexStep, error) {
-		garbage, err := l.toEOL()
+		garbage, _, err := l.toEOL()
 		if err != nil {
 			return nil, err
 		}
@@ -97,7 +97,7 @@ func (l *lexer) lexSectionSuffixFunc(section string) lexStep {
 func (l *lexer) ignoreLineFunc(next lexStep) lexStep {
 	return func() (lexStep, error) {
 		for {
-			line, err := l.toEOL()
+			line, _, err := l.toEOL()
 			if err != nil {
 				return nil, err
 			}
@@ -186,9 +186,13 @@ func (l *lexer) lexOptionValueFunc(section, name string) lexStep {
 		var partial bytes.Buffer
 
 		for {
-			line, err := l.toEOL()
+			line, eof, err := l.toEOL()
 			if err != nil {
 				return nil, err
+			}
+
+			if len(bytes.TrimSpace(line)) == 0 {
+				break
 			}
 
 			partial.Write(line)
@@ -199,27 +203,38 @@ func (l *lexer) lexOptionValueFunc(section, name string) lexStep {
 				break
 			}
 
-			partial.WriteRune('\n')
+			if !eof {
+				partial.WriteRune('\n')
+			}
 		}
 
-		val := strings.TrimSpace(partial.String())
+		val := partial.String()
+		if strings.HasSuffix(val, "\n") {
+			// A newline was added to the end, so the file didn't end with a backslash.
+			// => Keep the newline
+			val = strings.TrimSpace(val) + "\n"
+		} else {
+			val = strings.TrimSpace(val)
+		}
 		l.optchan <- &UnitOption{Section: section, Name: name, Value: val}
 
 		return l.lexNextSectionOrOptionFunc(section), nil
 	}
 }
 
-func (l *lexer) toEOL() ([]byte, error) {
+// toEOL reads until the end-of-line or end-of-file.
+// Returns (data, EOFfound, error)
+func (l *lexer) toEOL() ([]byte, bool, error) {
 	line, err := l.buf.ReadBytes('\n')
 	// ignore EOF here since it's roughly equivalent to EOL
 	if err != nil && err != io.EOF {
-		return nil, err
+		return nil, false, err
 	}
 
 	line = bytes.TrimSuffix(line, []byte{'\r'})
 	line = bytes.TrimSuffix(line, []byte{'\n'})
 
-	return line, nil
+	return line, err == io.EOF, nil
 }
 
 func isComment(r rune) bool {

--- a/unit/deserialize.go
+++ b/unit/deserialize.go
@@ -191,15 +191,15 @@ func (l *lexer) lexOptionValueFunc(section, name string) lexStep {
 				return nil, err
 			}
 
+			partial.Write(line)
+
 			// lack of continuation means this value has been exhausted
 			idx := bytes.LastIndex(line, []byte{'\\'})
 			if idx == -1 || idx != (len(line)-1) {
-				partial.Write(line)
 				break
 			}
 
-			partial.Write(line[0:idx])
-			partial.WriteRune(' ')
+			partial.WriteRune('\n')
 		}
 
 		val := strings.TrimSpace(partial.String())

--- a/unit/deserialize_test.go
+++ b/unit/deserialize_test.go
@@ -80,14 +80,15 @@ Environment= "FOO=BAR" "BAZ=QUX"
 			},
 		},
 
-		// line continuations respected
+		// line continuations unmodified
 		{
 			[]byte(`[Unit]
 Description= Unnecessarily wrapped \
     words here
 `),
 			[]*UnitOption{
-				&UnitOption{"Unit", "Description", "Unnecessarily wrapped      words here"},
+				&UnitOption{"Unit", "Description", `Unnecessarily wrapped \
+    words here`},
 			},
 		},
 
@@ -119,8 +120,8 @@ Description=Bar\
 Baz
 `),
 			[]*UnitOption{
-				&UnitOption{"Unit", "Description", "Bar # comment alpha"},
-				&UnitOption{"Unit", "Description", "Bar # comment bravo  Baz"},
+				&UnitOption{"Unit", "Description", "Bar\\\n# comment alpha"},
+				&UnitOption{"Unit", "Description", "Bar\\\n# comment bravo \\\nBaz"},
 			},
 		},
 
@@ -180,7 +181,7 @@ Description=Bar`),
 			[]byte(`[Unit]
 Description=Bar \`),
 			[]*UnitOption{
-				&UnitOption{"Unit", "Description", "Bar"},
+				&UnitOption{"Unit", "Description", "Bar \\"},
 			},
 		},
 
@@ -218,7 +219,7 @@ Description= words here `),
 Description= words here \
   `),
 			[]*UnitOption{
-				&UnitOption{"Unit", "Description", "words here"},
+				&UnitOption{"Unit", "Description", "words here \\"},
 			},
 		},
 

--- a/unit/deserialize_test.go
+++ b/unit/deserialize_test.go
@@ -219,7 +219,7 @@ Description= words here `),
 Description= words here \
   `),
 			[]*UnitOption{
-				&UnitOption{"Unit", "Description", "words here \\"},
+				&UnitOption{"Unit", "Description", "words here \\\n"},
 			},
 		},
 

--- a/unit/end_to_end_test.go
+++ b/unit/end_to_end_test.go
@@ -1,0 +1,76 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+)
+
+func TestDeserializeAndReserialize(t *testing.T) {
+	tests := []struct {
+		in   string
+		wout string
+	}{
+		{
+			`[Service]
+ExecStart=/bin/bash -c "while true; do echo \"ping\"; sleep 1; done"
+`,
+			`[Service]
+ExecStart=/bin/bash -c "while true; do echo \"ping\"; sleep 1; done"
+`},
+		{
+			`[Unit]
+Description= Unnecessarily wrapped \
+    words here`,
+			`[Unit]
+Description=Unnecessarily wrapped \
+    words here
+`,
+		},
+		{
+			`; comment alpha
+# comment bravo
+[Unit]
+; comment charlie
+# comment delta
+#Description=Foo
+Description=Bar
+; comment echo
+# comment foxtrot
+`,
+			`[Unit]
+Description=Bar
+`},
+	}
+	for i, tt := range tests {
+		ds, err := Deserialize(bytes.NewBufferString(tt.in))
+		if err != nil {
+			t.Errorf("case %d: unexpected error parsing unit: %v", i, err)
+			continue
+		}
+		out, err := ioutil.ReadAll(Serialize(ds))
+		if err != nil {
+			t.Errorf("case %d: unexpected error serializing unit: %v", i, err)
+			continue
+		}
+		if g := string(out); g != tt.wout {
+			t.Errorf("case %d: incorrect output", i)
+			t.Logf("Expected:\n%#v", tt.wout)
+			t.Logf("Actual:\n%#v", g)
+		}
+	}
+}

--- a/unit/end_to_end_test.go
+++ b/unit/end_to_end_test.go
@@ -42,6 +42,18 @@ Description=Unnecessarily wrapped \
 `,
 		},
 		{
+			`[Unit]
+Description=Demo \
+
+Requires=docker.service
+`,
+			`[Unit]
+Description=Demo \
+
+Requires=docker.service
+`,
+		},
+		{
 			`; comment alpha
 # comment bravo
 [Unit]


### PR DESCRIPTION
Builds on #103.

I added what IMHO is logic to properly reserve line continuation which I expressed in this dicussion: https://github.com/coreos/go-systemd/pull/103#discussion_r39170746
