### PR TITLE
sdjournal: import coreos.com/go-systemd/journal in test

### DIFF
--- a/sdjournal/journal_test.go
+++ b/sdjournal/journal_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/coreos/go-systemd/journal"
 )
 
 func TestJournalFollow(t *testing.T) {
@@ -46,15 +48,12 @@ func TestJournalFollow(t *testing.T) {
 	done := make(chan struct{}, 1)
 	defer close(done)
 	go func() {
-		j, err := NewJournal()
-		defer j.Close()
-
 		for {
 			select {
 			case <-done:
 				return
 			default:
-				if err = Print(PriInfo, "test message %s", time.Now()); err != nil {
+				if err = journal.Print(journal.PriInfo, "test message %s", time.Now()); err != nil {
 					t.Fatalf("Error writing to journal: %s", err)
 				}
 


### PR DESCRIPTION
Splitting the C bindings into sdjournal broke the test because
the test uses the native journal api to generate log activity.