### PR TITLE
Add interface for Inhibit method

### DIFF
--- a/login1/dbus.go
+++ b/login1/dbus.go
@@ -16,6 +16,7 @@
 package login1
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 
@@ -88,6 +89,17 @@ func (c *Conn) Inhibit(what, who, why, mode string) (*os.File, error) {
 	}
 
 	return os.NewFile(uintptr(fd), "inhibit"), nil
+}
+
+// Subscribe to signals on the logind dbus
+func (c *Conn) Subscribe(members ...string) chan *dbus.Signal {
+	for _, member := range members {
+		c.conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0,
+			fmt.Sprintf("type='signal',interface='org.freedesktop.login1.Manager',member='%s'", member))
+	}
+	ch := make(chan *dbus.Signal, 10)
+	c.conn.Signal(ch)
+	return ch
 }
 
 // PowerOff asks logind for a power off optionally asking for auth.

--- a/login1/dbus.go
+++ b/login1/dbus.go
@@ -78,6 +78,18 @@ func (c *Conn) Reboot(askForAuth bool) {
 	c.object.Call(dbusInterface+".Reboot", 0, askForAuth)
 }
 
+// Inhibit takes inhibition lock in logind.
+func (c *Conn) Inhibit(what, who, why, mode string) (*os.File, error) {
+	var fd dbus.UnixFD
+
+	err := c.object.Call(dbusInterface+".Inhibit", 0, what, who, why, mode).Store(&fd)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.NewFile(uintptr(fd), "inhibit"), nil
+}
+
 // PowerOff asks logind for a power off optionally asking for auth.
 func (c *Conn) PowerOff(askForAuth bool) {
 	c.object.Call(dbusInterface+".PowerOff", 0, askForAuth)


### PR DESCRIPTION
Adds interface for Inhibit method defined here: http://www.freedesktop.org/wiki/Software/systemd/inhibit/

The inhibit method is only useful if it is possible to subscribe to signals on the logind dbus. That's what the `Subscribe` method is for. It can be used like this:

```go
signal := login1Conn.Subscribe("PrepareForSleep")

sig := <-signal
switch sig.Name {
case "org.freedesktop.login1.Manager.PrepareForSleep":
    ....
}

```

Let me know if you think `Subcribe` should be done differently.