### PR TITLE
util: add ErrSoNotFound error var

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -65,6 +65,8 @@ import (
 	"unsafe"
 )
 
+var ErrSoNotFound = errors.New("unable to open a handle to libsystemd")
+
 // libHandle represents an open handle to the systemd C library
 type libHandle struct {
 	handle  unsafe.Pointer
@@ -103,7 +105,7 @@ func getHandle() (*libHandle, error) {
 			return h, nil
 		}
 	}
-	return nil, errors.New("unable to open a handle to libsystemd")
+	return nil, ErrSoNotFound
 }
 
 // GetRunningSlice attempts to retrieve the name of the systemd slice in which


### PR DESCRIPTION
This allows rkt to detect that the problem was that we couldn't open
libsystemd and just warn the user.

For example, NixOS has shared libraries in weird paths and we don't want
to just fail if we can't find it. See
https://github.com/coreos/rkt/issues/1879