### PR TITLE
Enable reading of the journal from a custom directory

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -25,7 +25,7 @@
 package sdjournal
 
 /*
-#cgo pkg-config: libsystemd-journal
+#cgo pkg-config: libsystemd
 #include <systemd/sd-journal.h>
 #include <stdlib.h>
 #include <syslog.h>
@@ -81,6 +81,26 @@ func NewJournal() (*Journal, error) {
 
 	if err < 0 {
 		return nil, fmt.Errorf("failed to open journal: %s", err)
+	}
+
+	return j, nil
+}
+
+// NewJournalFromDir returns a new Journal instance pointing to a journal residing
+// in a given directory.  Typically, the directory will be appended with /<machine-id>
+// which can be generated from util.GetMachineID() from this same library.
+func NewJournalFromDir(path string) (*Journal, error) {
+	if len(path) == 0 {
+		return nil, fmt.Errorf("failed to open journal; provided path is nil:")
+	}
+
+	p := C.CString(path)
+	defer C.free(unsafe.Pointer(p))
+
+	j := &Journal{}
+	errInt := C.sd_journal_open_directory(&j.cjournal, p, 0)
+	if errInt < 0 {
+		return nil, fmt.Errorf("failed to open journal in directory %v: %v", path, errInt)
 	}
 
 	return j, nil

--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -33,6 +33,7 @@ package sdjournal
 import "C"
 import (
 	"fmt"
+	"path/filepath"
 	"sync"
 	"time"
 	"unsafe"
@@ -90,8 +91,9 @@ func NewJournal() (*Journal, error) {
 // in a given directory.  Typically, the directory will be appended with /<machine-id>
 // which can be generated from util.GetMachineID() from this same library.
 func NewJournalFromDir(path string) (*Journal, error) {
-	if len(path) == 0 {
-		return nil, fmt.Errorf("failed to open journal; provided path is nil:")
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
 	}
 
 	p := C.CString(path)

--- a/util/util.go
+++ b/util/util.go
@@ -60,6 +60,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"syscall"
 	"unsafe"
@@ -253,4 +254,20 @@ func IsRunningSystemd() bool {
 		return false
 	}
 	return fi.IsDir()
+}
+
+// GetMachineID returns a host's 128-bit machine ID as a string.
+func GetMachineID() (machineID string, err error) {
+	// There is a systemd library function, sd_id128_get_machine, which can be used
+	// to obtain the machine ID.  However, that function simply reads the string
+	// from /etc/machine-id on the filesystem. To simplify things, we'll just read
+	// it directly from the file, too.
+	systemID, err := ioutil.ReadFile("/etc/machine-id")
+	if err != nil {
+		fmt.Errorf("Failed to read /etc/machine-id: %v", err)
+		return
+	}
+	// Chop off the trailing newline
+	machineID = string(systemID[:len(systemID)-1])
+	return machineID, nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -62,6 +62,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"syscall"
 	"unsafe"
 )
@@ -256,18 +257,14 @@ func IsRunningSystemd() bool {
 	return fi.IsDir()
 }
 
-// GetMachineID returns a host's 128-bit machine ID as a string.
-func GetMachineID() (machineID string, err error) {
-	// There is a systemd library function, sd_id128_get_machine, which can be used
-	// to obtain the machine ID.  However, that function simply reads the string
-	// from /etc/machine-id on the filesystem. To simplify things, we'll just read
-	// it directly from the file, too.
-	systemID, err := ioutil.ReadFile("/etc/machine-id")
+// GetMachineID returns a host's 128-bit machine ID as a string. There is a systemd
+// library function, sd_id128_get_machine, which can be used to obtain the
+// machine ID.  However, this function simply reads the string from /etc/machine-id.
+// To simplify things, we'll just read it directly from the file, too.
+func GetMachineID() (string, error) {
+	machineID, err := ioutil.ReadFile("/etc/machine-id")
 	if err != nil {
-		fmt.Errorf("Failed to read /etc/machine-id: %v", err)
-		return
+		return "", fmt.Errorf("failed to read /etc/machine-id: %v", err)
 	}
-	// Chop off the trailing newline
-	machineID = string(systemID[:len(systemID)-1])
-	return machineID, nil
+	return strings.TrimSpace(string(machineID)), nil
 }


### PR DESCRIPTION
This PR enables the user to read the system journal from a custom (alternate) directory by offering an interface to the ```sd_journal_open_directory()``` function.

It also adds a ```GetMachineID()``` convenience function, useful for typical journald storage directories that include the machine-id in the path.