### PR TITLE
Close the tempfile when journaling large messages

### DIFF
--- a/journal/journal.go
+++ b/journal/journal.go
@@ -90,6 +90,7 @@ func Send(message string, priority Priority, vars map[string]string) error {
 		if err != nil {
 			return journalError(err.Error())
 		}
+		defer file.Close()
 		_, err = io.Copy(file, data)
 		if err != nil {
 			return journalError(err.Error())


### PR DESCRIPTION
When we fail to log a message to journald due to ENOBUFS or EMSGSIZE, we attempt to pass the message to journald by passing it a descriptor attached to some shared memory.  Since we won't be touching it again, we need to close the descriptor after we send it.