### PR TITLE
sdjournal: dlopen libsystemd instead of linking against it

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -24,12 +24,172 @@
 // [1] http://www.freedesktop.org/software/systemd/man/sd-journal.html
 package sdjournal
 
-/*
-#cgo pkg-config: libsystemd
-#include <systemd/sd-journal.h>
-#include <stdlib.h>
-#include <syslog.h>
-*/
+// #include <systemd/sd-journal.h>
+// #include <stdlib.h>
+// #include <syslog.h>
+//
+// int
+// my_sd_journal_open(void *f, sd_journal **ret, int flags)
+// {
+//   int (*sd_journal_open)(sd_journal **, int);
+//
+//   sd_journal_open = f;
+//   return sd_journal_open(ret, flags);
+// }
+//
+// int
+// my_sd_journal_open_directory(void *f, sd_journal **ret, const char *path, int flags)
+// {
+//   int (*sd_journal_open_directory)(sd_journal **, const char *, int);
+//
+//   sd_journal_open_directory = f;
+//   return sd_journal_open_directory(ret, path, flags);
+// }
+//
+// void
+// my_sd_journal_close(void *f, sd_journal *j)
+// {
+//   int (*sd_journal_close)(sd_journal *);
+//
+//   sd_journal_close = f;
+//   sd_journal_close(j);
+// }
+//
+// int
+// my_sd_journal_get_usage(void *f, sd_journal *j, uint64_t *bytes)
+// {
+//   int (*sd_journal_get_usage)(sd_journal *, uint64_t *);
+//
+//   sd_journal_get_usage = f;
+//   return sd_journal_get_usage(j, bytes);
+// }
+//
+// int
+// my_sd_journal_add_match(void *f, sd_journal *j, const void *data, size_t size)
+// {
+//   int (*sd_journal_add_match)(sd_journal *, const void *, size_t);
+//
+//   sd_journal_add_match = f;
+//   return sd_journal_add_match(j, data, size);
+// }
+//
+// int
+// my_sd_journal_add_disjunction(void *f, sd_journal *j)
+// {
+//   int (*sd_journal_add_disjunction)(sd_journal *);
+//
+//   sd_journal_add_disjunction = f;
+//   return sd_journal_add_disjunction(j);
+// }
+//
+// int
+// my_sd_journal_add_conjunction(void *f, sd_journal *j)
+// {
+//   int (*sd_journal_add_conjunction)(sd_journal *);
+//
+//   sd_journal_add_conjunction = f;
+//   return sd_journal_add_conjunction(j);
+// }
+//
+// void
+// my_sd_journal_flush_matches(void *f, sd_journal *j)
+// {
+//   int (*sd_journal_flush_matches)(sd_journal *);
+//
+//   sd_journal_flush_matches = f;
+//   sd_journal_flush_matches(j);
+// }
+//
+// int
+// my_sd_journal_next(void *f, sd_journal *j)
+// {
+//   int (*sd_journal_next)(sd_journal *);
+//
+//   sd_journal_next = f;
+//   return sd_journal_next(j);
+// }
+//
+// int
+// my_sd_journal_next_skip(void *f, sd_journal *j, uint64_t skip)
+// {
+//   int (*sd_journal_next_skip)(sd_journal *, uint64_t);
+//
+//   sd_journal_next_skip = f;
+//   return sd_journal_next_skip(j, skip);
+// }
+//
+// int
+// my_sd_journal_previous(void *f, sd_journal *j)
+// {
+//   int (*sd_journal_previous)(sd_journal *);
+//
+//   sd_journal_previous = f;
+//   return sd_journal_previous(j);
+// }
+//
+// int
+// my_sd_journal_previous_skip(void *f, sd_journal *j, uint64_t skip)
+// {
+//   int (*sd_journal_previous_skip)(sd_journal *, uint64_t);
+//
+//   sd_journal_previous_skip = f;
+//   return sd_journal_previous_skip(j, skip);
+// }
+//
+// int
+// my_sd_journal_get_data(void *f, sd_journal *j, const char *field, const void **data, size_t *length)
+// {
+//   int (*sd_journal_get_data)(sd_journal *, const char *, const void **, size_t *);
+//
+//   sd_journal_get_data = f;
+//   return sd_journal_get_data(j, field, data, length);
+// }
+//
+// int
+// my_sd_journal_set_data_threshold(void *f, sd_journal *j, size_t sz)
+// {
+//   int (*sd_journal_set_data_threshold)(sd_journal *, size_t);
+//
+//   sd_journal_set_data_threshold = f;
+//   return sd_journal_set_data_threshold(j, sz);
+// }
+//
+// int
+// my_sd_journal_get_realtime_usec(void *f, sd_journal *j, uint64_t *usec)
+// {
+//   int (*sd_journal_get_realtime_usec)(sd_journal *, uint64_t *);
+//
+//   sd_journal_get_realtime_usec = f;
+//   return sd_journal_get_realtime_usec(j, usec);
+// }
+//
+// int
+// my_sd_journal_seek_tail(void *f, sd_journal *j)
+// {
+//   int (*sd_journal_seek_tail)(sd_journal *);
+//
+//   sd_journal_seek_tail = f;
+//   return sd_journal_seek_tail(j);
+// }
+//
+// int
+// my_sd_journal_seek_realtime_usec(void *f, sd_journal *j, uint64_t usec)
+// {
+//   int (*sd_journal_seek_realtime_usec)(sd_journal *, uint64_t);
+//
+//   sd_journal_seek_realtime_usec = f;
+//   return sd_journal_seek_realtime_usec(j, usec);
+// }
+//
+// int
+// my_sd_journal_wait(void *f, sd_journal *j, uint64_t timeout_usec)
+// {
+//   int (*sd_journal_wait)(sd_journal *, uint64_t);
+//
+//   sd_journal_wait = f;
+//   return sd_journal_wait(j, timeout_usec);
+// }
+//
 import "C"
 import (
 	"fmt"
@@ -38,7 +198,11 @@ import (
 	"sync"
 	"time"
 	"unsafe"
+
+	"github.com/coreos/pkg/dlopen"
 )
+
+var libsystemdFunctions = map[string]unsafe.Pointer{}
 
 // Journal entry field strings which correspond to:
 // http://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html
@@ -67,10 +231,21 @@ const (
 	IndefiniteWait time.Duration = 1<<63 - 1
 )
 
+var libsystemdNames = []string{
+	// systemd < 209
+	"libsystemd-journal.so.0",
+	"libsystemd-journal.so",
+
+	// systemd >= 209 merged libsystemd-journal into libsystemd proper
+	"libsystemd.so.0",
+	"libsystemd.so",
+}
+
 // Journal is a Go wrapper of an sd_journal structure.
 type Journal struct {
 	cjournal *C.sd_journal
 	mu       sync.Mutex
+	lib      *dlopen.LibHandle
 }
 
 // Match is a convenience wrapper to describe filters supplied to AddMatch.
@@ -84,10 +259,36 @@ func (m *Match) String() string {
 	return m.Field + "=" + m.Value
 }
 
+func (j *Journal) getFunction(name string) (unsafe.Pointer, error) {
+	f, ok := libsystemdFunctions[name]
+	if !ok {
+		var err error
+		f, err = j.lib.GetSymbolPointer(name)
+		if err != nil {
+			return nil, err
+		}
+
+		libsystemdFunctions[name] = f
+	}
+
+	return f, nil
+}
+
 // NewJournal returns a new Journal instance pointing to the local journal
 func NewJournal() (*Journal, error) {
-	j := &Journal{}
-	r := C.sd_journal_open(&j.cjournal, C.SD_JOURNAL_LOCAL_ONLY)
+	h, err := dlopen.GetHandle(libsystemdNames)
+	if err != nil {
+		return nil, err
+	}
+
+	j := &Journal{lib: h}
+
+	sd_journal_open, err := j.getFunction("sd_journal_open")
+	if err != nil {
+		return nil, err
+	}
+
+	r := C.my_sd_journal_open(sd_journal_open, &j.cjournal, C.SD_JOURNAL_LOCAL_ONLY)
 
 	if r < 0 {
 		return nil, fmt.Errorf("failed to open journal: %d", r)
@@ -100,7 +301,19 @@ func NewJournal() (*Journal, error) {
 // in a given directory. The supplied path may be relative or absolute; if
 // relative, it will be converted to an absolute path before being opened.
 func NewJournalFromDir(path string) (*Journal, error) {
-	path, err := filepath.Abs(path)
+	h, err := dlopen.GetHandle(libsystemdNames)
+	if err != nil {
+		return nil, err
+	}
+
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	j := &Journal{lib: h}
+
+	sd_journal_open_directory, err := j.getFunction("sd_journal_open_directory")
 	if err != nil {
 		return nil, err
 	}
@@ -108,8 +321,7 @@ func NewJournalFromDir(path string) (*Journal, error) {
 	p := C.CString(path)
 	defer C.free(unsafe.Pointer(p))
 
-	j := &Journal{}
-	r := C.sd_journal_open_directory(&j.cjournal, p, 0)
+	r := C.my_sd_journal_open_directory(sd_journal_open_directory, &j.cjournal, p, 0)
 	if r < 0 {
 		return nil, fmt.Errorf("failed to open journal in directory %q: %d", path, r)
 	}
@@ -119,20 +331,30 @@ func NewJournalFromDir(path string) (*Journal, error) {
 
 // Close closes a journal opened with NewJournal.
 func (j *Journal) Close() error {
+	sd_journal_close, err := j.getFunction("sd_journal_close")
+	if err != nil {
+		return err
+	}
+
 	j.mu.Lock()
-	C.sd_journal_close(j.cjournal)
+	C.my_sd_journal_close(sd_journal_close, j.cjournal)
 	j.mu.Unlock()
 
-	return nil
+	return j.lib.Close()
 }
 
 // AddMatch adds a match by which to filter the entries of the journal.
 func (j *Journal) AddMatch(match string) error {
+	sd_journal_add_match, err := j.getFunction("sd_journal_add_match")
+	if err != nil {
+		return err
+	}
+
 	m := C.CString(match)
 	defer C.free(unsafe.Pointer(m))
 
 	j.mu.Lock()
-	r := C.sd_journal_add_match(j.cjournal, unsafe.Pointer(m), C.size_t(len(match)))
+	r := C.my_sd_journal_add_match(sd_journal_add_match, j.cjournal, unsafe.Pointer(m), C.size_t(len(match)))
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -144,8 +366,13 @@ func (j *Journal) AddMatch(match string) error {
 
 // AddDisjunction inserts a logical OR in the match list.
 func (j *Journal) AddDisjunction() error {
+	sd_journal_add_disjunction, err := j.getFunction("sd_journal_add_disjunction")
+	if err != nil {
+		return err
+	}
+
 	j.mu.Lock()
-	r := C.sd_journal_add_disjunction(j.cjournal)
+	r := C.my_sd_journal_add_disjunction(sd_journal_add_disjunction, j.cjournal)
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -157,8 +384,13 @@ func (j *Journal) AddDisjunction() error {
 
 // AddConjunction inserts a logical AND in the match list.
 func (j *Journal) AddConjunction() error {
+	sd_journal_add_conjunction, err := j.getFunction("sd_journal_add_conjunction")
+	if err != nil {
+		return err
+	}
+
 	j.mu.Lock()
-	r := C.sd_journal_add_conjunction(j.cjournal)
+	r := C.my_sd_journal_add_conjunction(sd_journal_add_conjunction, j.cjournal)
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -170,15 +402,25 @@ func (j *Journal) AddConjunction() error {
 
 // FlushMatches flushes all matches, disjunctions and conjunctions.
 func (j *Journal) FlushMatches() {
+	sd_journal_flush_matches, err := j.getFunction("sd_journal_flush_matches")
+	if err != nil {
+		return
+	}
+
 	j.mu.Lock()
-	C.sd_journal_flush_matches(j.cjournal)
+	C.my_sd_journal_flush_matches(sd_journal_flush_matches, j.cjournal)
 	j.mu.Unlock()
 }
 
 // Next advances the read pointer into the journal by one entry.
 func (j *Journal) Next() (int, error) {
+	sd_journal_next, err := j.getFunction("sd_journal_next")
+	if err != nil {
+		return -1, err
+	}
+
 	j.mu.Lock()
-	r := C.sd_journal_next(j.cjournal)
+	r := C.my_sd_journal_next(sd_journal_next, j.cjournal)
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -191,8 +433,13 @@ func (j *Journal) Next() (int, error) {
 // NextSkip advances the read pointer by multiple entries at once,
 // as specified by the skip parameter.
 func (j *Journal) NextSkip(skip uint64) (uint64, error) {
+	sd_journal_next_skip, err := j.getFunction("sd_journal_next_skip")
+	if err != nil {
+		return 0, err
+	}
+
 	j.mu.Lock()
-	r := C.sd_journal_next_skip(j.cjournal, C.uint64_t(skip))
+	r := C.my_sd_journal_next_skip(sd_journal_next_skip, j.cjournal, C.uint64_t(skip))
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -204,8 +451,13 @@ func (j *Journal) NextSkip(skip uint64) (uint64, error) {
 
 // Previous sets the read pointer into the journal back by one entry.
 func (j *Journal) Previous() (uint64, error) {
+	sd_journal_previous, err := j.getFunction("sd_journal_previous")
+	if err != nil {
+		return 0, err
+	}
+
 	j.mu.Lock()
-	r := C.sd_journal_previous(j.cjournal)
+	r := C.my_sd_journal_previous(sd_journal_previous, j.cjournal)
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -218,8 +470,13 @@ func (j *Journal) Previous() (uint64, error) {
 // PreviousSkip sets back the read pointer by multiple entries at once,
 // as specified by the skip parameter.
 func (j *Journal) PreviousSkip(skip uint64) (uint64, error) {
+	sd_journal_previous_skip, err := j.getFunction("sd_journal_previous_skip")
+	if err != nil {
+		return 0, err
+	}
+
 	j.mu.Lock()
-	r := C.sd_journal_previous_skip(j.cjournal, C.uint64_t(skip))
+	r := C.my_sd_journal_previous_skip(sd_journal_previous_skip, j.cjournal, C.uint64_t(skip))
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -232,6 +489,11 @@ func (j *Journal) PreviousSkip(skip uint64) (uint64, error) {
 // GetData gets the data object associated with a specific field from the
 // current journal entry.
 func (j *Journal) GetData(field string) (string, error) {
+	sd_journal_get_data, err := j.getFunction("sd_journal_get_data")
+	if err != nil {
+		return "", err
+	}
+
 	f := C.CString(field)
 	defer C.free(unsafe.Pointer(f))
 
@@ -239,7 +501,7 @@ func (j *Journal) GetData(field string) (string, error) {
 	var l C.size_t
 
 	j.mu.Lock()
-	r := C.sd_journal_get_data(j.cjournal, f, &d, &l)
+	r := C.my_sd_journal_get_data(sd_journal_get_data, j.cjournal, f, &d, &l)
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -266,8 +528,13 @@ func (j *Journal) GetDataValue(field string) (string, error) {
 // turned off by setting it to 0, so that the library always returns the
 // complete data objects.
 func (j *Journal) SetDataThreshold(threshold uint64) error {
+	sd_journal_set_data_threshold, err := j.getFunction("sd_journal_set_data_threshold")
+	if err != nil {
+		return err
+	}
+
 	j.mu.Lock()
-	r := C.sd_journal_set_data_threshold(j.cjournal, C.size_t(threshold))
+	r := C.my_sd_journal_set_data_threshold(sd_journal_set_data_threshold, j.cjournal, C.size_t(threshold))
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -282,8 +549,13 @@ func (j *Journal) SetDataThreshold(threshold uint64) error {
 func (j *Journal) GetRealtimeUsec() (uint64, error) {
 	var usec C.uint64_t
 
+	sd_journal_get_realtime_usec, err := j.getFunction("sd_journal_get_realtime_usec")
+	if err != nil {
+		return 0, err
+	}
+
 	j.mu.Lock()
-	r := C.sd_journal_get_realtime_usec(j.cjournal, &usec)
+	r := C.my_sd_journal_get_realtime_usec(sd_journal_get_realtime_usec, j.cjournal, &usec)
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -296,8 +568,13 @@ func (j *Journal) GetRealtimeUsec() (uint64, error) {
 // SeekTail may be used to seek to the end of the journal, i.e. the most recent
 // available entry.
 func (j *Journal) SeekTail() error {
+	sd_journal_seek_tail, err := j.getFunction("sd_journal_seek_tail")
+	if err != nil {
+		return err
+	}
+
 	j.mu.Lock()
-	r := C.sd_journal_seek_tail(j.cjournal)
+	r := C.my_sd_journal_seek_tail(sd_journal_seek_tail, j.cjournal)
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -310,8 +587,13 @@ func (j *Journal) SeekTail() error {
 // SeekRealtimeUsec seeks to the entry with the specified realtime (wallclock)
 // timestamp, i.e. CLOCK_REALTIME.
 func (j *Journal) SeekRealtimeUsec(usec uint64) error {
+	sd_journal_seek_realtime_usec, err := j.getFunction("sd_journal_seek_realtime_usec")
+	if err != nil {
+		return err
+	}
+
 	j.mu.Lock()
-	r := C.sd_journal_seek_realtime_usec(j.cjournal, C.uint64_t(usec))
+	r := C.my_sd_journal_seek_realtime_usec(sd_journal_seek_realtime_usec, j.cjournal, C.uint64_t(usec))
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -327,6 +609,12 @@ func (j *Journal) SeekRealtimeUsec(usec uint64) error {
 // wait indefinitely for a journal change.
 func (j *Journal) Wait(timeout time.Duration) int {
 	var to uint64
+
+	sd_journal_wait, err := j.getFunction("sd_journal_wait")
+	if err != nil {
+		return -1
+	}
+
 	if timeout == IndefiniteWait {
 		// sd_journal_wait(3) calls for a (uint64_t) -1 to be passed to signify
 		// indefinite wait, but using a -1 overflows our C.uint64_t, so we use an
@@ -336,7 +624,7 @@ func (j *Journal) Wait(timeout time.Duration) int {
 		to = uint64(time.Now().Add(timeout).Unix() / 1000)
 	}
 	j.mu.Lock()
-	r := C.sd_journal_wait(j.cjournal, C.uint64_t(to))
+	r := C.my_sd_journal_wait(sd_journal_wait, j.cjournal, C.uint64_t(to))
 	j.mu.Unlock()
 
 	return int(r)
@@ -345,8 +633,14 @@ func (j *Journal) Wait(timeout time.Duration) int {
 // GetUsage returns the journal disk space usage, in bytes.
 func (j *Journal) GetUsage() (uint64, error) {
 	var out C.uint64_t
+
+	sd_journal_get_usage, err := j.getFunction("sd_journal_get_usage")
+	if err != nil {
+		return 0, err
+	}
+
 	j.mu.Lock()
-	r := C.sd_journal_get_usage(j.cjournal, &out)
+	r := C.my_sd_journal_get_usage(sd_journal_get_usage, j.cjournal, &out)
 	j.mu.Unlock()
 
 	if r < 0 {

--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -196,6 +196,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 	"unsafe"
 
@@ -291,7 +292,7 @@ func NewJournal() (*Journal, error) {
 	r := C.my_sd_journal_open(sd_journal_open, &j.cjournal, C.SD_JOURNAL_LOCAL_ONLY)
 
 	if r < 0 {
-		return nil, fmt.Errorf("failed to open journal: %d", r)
+		return nil, fmt.Errorf("failed to open journal: %d", syscall.Errno(-r))
 	}
 
 	return j, nil
@@ -323,7 +324,7 @@ func NewJournalFromDir(path string) (*Journal, error) {
 
 	r := C.my_sd_journal_open_directory(sd_journal_open_directory, &j.cjournal, p, 0)
 	if r < 0 {
-		return nil, fmt.Errorf("failed to open journal in directory %q: %d", path, r)
+		return nil, fmt.Errorf("failed to open journal in directory %q: %d", path, syscall.Errno(-r))
 	}
 
 	return j, nil
@@ -358,7 +359,7 @@ func (j *Journal) AddMatch(match string) error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to add match: %d", r)
+		return fmt.Errorf("failed to add match: %d", syscall.Errno(-r))
 	}
 
 	return nil
@@ -376,7 +377,7 @@ func (j *Journal) AddDisjunction() error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to add a disjunction in the match list: %d", r)
+		return fmt.Errorf("failed to add a disjunction in the match list: %d", syscall.Errno(-r))
 	}
 
 	return nil
@@ -394,7 +395,7 @@ func (j *Journal) AddConjunction() error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to add a conjunction in the match list: %d", r)
+		return fmt.Errorf("failed to add a conjunction in the match list: %d", syscall.Errno(-r))
 	}
 
 	return nil
@@ -424,7 +425,7 @@ func (j *Journal) Next() (int, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return int(r), fmt.Errorf("failed to iterate journal: %d", r)
+		return int(r), fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
 	}
 
 	return int(r), nil
@@ -443,7 +444,7 @@ func (j *Journal) NextSkip(skip uint64) (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return uint64(r), fmt.Errorf("failed to iterate journal: %d", r)
+		return uint64(r), fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
 	}
 
 	return uint64(r), nil
@@ -461,7 +462,7 @@ func (j *Journal) Previous() (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return uint64(r), fmt.Errorf("failed to iterate journal: %d", r)
+		return uint64(r), fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
 	}
 
 	return uint64(r), nil
@@ -480,7 +481,7 @@ func (j *Journal) PreviousSkip(skip uint64) (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return uint64(r), fmt.Errorf("failed to iterate journal: %d", r)
+		return uint64(r), fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
 	}
 
 	return uint64(r), nil
@@ -505,7 +506,7 @@ func (j *Journal) GetData(field string) (string, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return "", fmt.Errorf("failed to read message: %d", r)
+		return "", fmt.Errorf("failed to read message: %d", syscall.Errno(-r))
 	}
 
 	msg := C.GoStringN((*C.char)(d), C.int(l))
@@ -538,7 +539,7 @@ func (j *Journal) SetDataThreshold(threshold uint64) error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to set data threshold: %d", r)
+		return fmt.Errorf("failed to set data threshold: %d", syscall.Errno(-r))
 	}
 
 	return nil
@@ -559,7 +560,7 @@ func (j *Journal) GetRealtimeUsec() (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return 0, fmt.Errorf("error getting timestamp for entry: %d", r)
+		return 0, fmt.Errorf("error getting timestamp for entry: %d", syscall.Errno(-r))
 	}
 
 	return uint64(usec), nil
@@ -578,7 +579,7 @@ func (j *Journal) SeekTail() error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to seek to tail of journal: %d", r)
+		return fmt.Errorf("failed to seek to tail of journal: %d", syscall.Errno(-r))
 	}
 
 	return nil
@@ -597,7 +598,7 @@ func (j *Journal) SeekRealtimeUsec(usec uint64) error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to seek to %d: %d", usec, r)
+		return fmt.Errorf("failed to seek to %d: %d", usec, syscall.Errno(-r))
 	}
 
 	return nil
@@ -644,7 +645,7 @@ func (j *Journal) GetUsage() (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return 0, fmt.Errorf("failed to get journal disk space usage: %d", r)
+		return 0, fmt.Errorf("failed to get journal disk space usage: %d", syscall.Errno(-r))
 	}
 
 	return uint64(out), nil

--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -261,6 +261,8 @@ func (m *Match) String() string {
 }
 
 func (j *Journal) getFunction(name string) (unsafe.Pointer, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
 	f, ok := libsystemdFunctions[name]
 	if !ok {
 		var err error

--- a/util/util.go
+++ b/util/util.go
@@ -18,9 +18,7 @@
 // than linking against them.
 package util
 
-// #cgo LDFLAGS: -ldl
 // #include <stdlib.h>
-// #include <dlfcn.h>
 // #include <sys/types.h>
 // #include <unistd.h>
 //
@@ -58,56 +56,24 @@ package util
 // }
 import "C"
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
 	"syscall"
 	"unsafe"
+
+	"github.com/coreos/pkg/dlopen"
 )
 
-var ErrSoNotFound = errors.New("unable to open a handle to libsystemd")
+var libsystemdNames = []string{
+	// systemd < 209
+	"libsystemd-login.so.0",
+	"libsystemd-login.so",
 
-// libHandle represents an open handle to the systemd C library
-type libHandle struct {
-	handle  unsafe.Pointer
-	libname string
-}
-
-func (h *libHandle) Close() error {
-	if r := C.dlclose(h.handle); r != 0 {
-		return fmt.Errorf("error closing %v: %d", h.libname, r)
-	}
-	return nil
-}
-
-// getHandle tries to get a handle to a systemd library (.so), attempting to
-// access it by several different names and returning the first that is
-// successfully opened. Callers are responsible for closing the handler.
-// If no library can be successfully opened, an error is returned.
-func getHandle() (*libHandle, error) {
-	for _, name := range []string{
-		// systemd < 209
-		"libsystemd-login.so",
-		"libsystemd-login.so.0",
-
-		// systemd >= 209 merged libsystemd-login into libsystemd proper
-		"libsystemd.so",
-		"libsystemd.so.0",
-	} {
-		libname := C.CString(name)
-		defer C.free(unsafe.Pointer(libname))
-		handle := C.dlopen(libname, C.RTLD_LAZY)
-		if handle != nil {
-			h := &libHandle{
-				handle:  handle,
-				libname: name,
-			}
-			return h, nil
-		}
-	}
-	return nil, ErrSoNotFound
+	// systemd >= 209 merged libsystemd-login into libsystemd proper
+	"libsystemd.so.0",
+	"libsystemd.so",
 }
 
 // GetRunningSlice attempts to retrieve the name of the systemd slice in which
@@ -115,8 +81,8 @@ func getHandle() (*libHandle, error) {
 // This function is a wrapper around the libsystemd C library; if it cannot be
 // opened, an error is returned.
 func GetRunningSlice() (slice string, err error) {
-	var h *libHandle
-	h, err = getHandle()
+	var h *dlopen.LibHandle
+	h, err = dlopen.GetHandle(libsystemdNames)
 	if err != nil {
 		return
 	}
@@ -126,11 +92,8 @@ func GetRunningSlice() (slice string, err error) {
 		}
 	}()
 
-	sym := C.CString("sd_pid_get_slice")
-	defer C.free(unsafe.Pointer(sym))
-	sd_pid_get_slice := C.dlsym(h.handle, sym)
-	if sd_pid_get_slice == nil {
-		err = fmt.Errorf("error resolving sd_pid_get_slice function")
+	sd_pid_get_slice, err := h.GetSymbolPointer("sd_pid_get_slice")
+	if err != nil {
 		return
 	}
 
@@ -164,8 +127,8 @@ func GetRunningSlice() (slice string, err error) {
 // unable to successfully open a handle to the library for any reason (e.g. it
 // cannot be found), an errr will be returned
 func RunningFromSystemService() (ret bool, err error) {
-	var h *libHandle
-	h, err = getHandle()
+	var h *dlopen.LibHandle
+	h, err = dlopen.GetHandle(libsystemdNames)
 	if err != nil {
 		return
 	}
@@ -175,11 +138,8 @@ func RunningFromSystemService() (ret bool, err error) {
 		}
 	}()
 
-	sym := C.CString("sd_pid_get_owner_uid")
-	defer C.free(unsafe.Pointer(sym))
-	sd_pid_get_owner_uid := C.dlsym(h.handle, sym)
-	if sd_pid_get_owner_uid == nil {
-		err = fmt.Errorf("error resolving sd_pid_get_owner_uid function")
+	sd_pid_get_owner_uid, err := h.GetSymbolPointer("sd_pid_get_owner_uid")
+	if err != nil {
 		return
 	}
 
@@ -212,8 +172,8 @@ func RunningFromSystemService() (ret bool, err error) {
 // `sd_pid_get_unit` call, with the same caveat: for processes not part of a
 // systemd system unit, this function will return an error.
 func CurrentUnitName() (unit string, err error) {
-	var h *libHandle
-	h, err = getHandle()
+	var h *dlopen.LibHandle
+	h, err = dlopen.GetHandle(libsystemdNames)
 	if err != nil {
 		return
 	}
@@ -223,11 +183,8 @@ func CurrentUnitName() (unit string, err error) {
 		}
 	}()
 
-	sym := C.CString("sd_pid_get_unit")
-	defer C.free(unsafe.Pointer(sym))
-	sd_pid_get_unit := C.dlsym(h.handle, sym)
-	if sd_pid_get_unit == nil {
-		err = fmt.Errorf("error resolving sd_pid_get_unit function")
+	sd_pid_get_unit, err := h.GetSymbolPointer("sd_pid_get_unit")
+	if err != nil {
 		return
 	}
 


### PR DESCRIPTION
This allows not having to link users of the library to libsystemd,
detect at runtime if it exists or not and react accordingly.

Also, refactor dlopen code.