### PR TITLE
Follow with filter

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -251,6 +251,31 @@ func (j *Journal) GetData(field string) (string, error) {
 	return msg, nil
 }
 
+// EnumerateData may be used to iterate through all data fields used in the opened journal files
+// the order of the returned field names is not defined.
+func (j *Journal) EnumerateData() (string, error) {
+	var d unsafe.Pointer
+	var l C.size_t
+
+	j.mu.Lock()
+	r := C.sd_journal_enumerate_data(j.cjournal, &d, &l)
+	j.mu.Unlock()
+
+	if r < 0 {
+		return "", fmt.Errorf("failed to read message: %d", r)
+	}
+
+	msg := C.GoStringN((*C.char)(d), C.int(l))
+	return msg, nil
+}
+
+//RestartData resets the field name enumeration index to the beginning of the list.
+func (j *Journal) RestartData() {
+	j.mu.Lock()
+	C.sd_journal_restart_data(j.cjournal)
+	j.mu.Unlock()
+}
+
 // GetDataValue gets the data object associated with a specific field from the
 // current journal entry, returning only the value of the object.
 func (j *Journal) GetDataValue(field string) (string, error) {

--- a/sdjournal/read.go
+++ b/sdjournal/read.go
@@ -190,7 +190,10 @@ process:
 	return
 }
 
-func (r *JournalReader) FollowWithFields(until <-chan time.Time, fields map[string]struct{}, writer io.Writer) (err error) {
+// FollowWithFields synchronously follows the Journal, writing each full Journal Entry with all its given fields
+// as a map to the writer. Similar to Follow(), it will continue until a single time.Time is
+// received on the until channel.
+func (r *JournalReader) FollowWithFields(until <-chan time.Time, writer io.Writer) (err error) {
 	enc := json.NewEncoder(writer)
 journal:
 	for {
@@ -222,10 +225,7 @@ journal:
 					}
 					s = s[:len(s)]
 					arr := strings.SplitN(s, "=", 2)
-					if _, ok := fields[arr[0]]; ok {
-						kvMap[arr[0]] = arr[1]
-					}
-
+					kvMap[arr[0]] = arr[1]
 				}
 				if err := enc.Encode(kvMap); err != nil {
 					return err

--- a/sdjournal/read.go
+++ b/sdjournal/read.go
@@ -16,13 +16,14 @@
 package sdjournal
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"strings"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 var (
@@ -49,6 +50,22 @@ type JournalReaderConfig struct {
 // systemd journal.
 type JournalReader struct {
 	journal *Journal
+}
+
+// FollowFilter is a function which you pass into Follow to determine if you to
+// filter key value pair from a journal entry.
+type FollowFilter func(key, value string) bool
+
+// AllKeys is a FollowFilter that allows all keys of a given journal entry through the filter
+func AllKeys(key, value string) bool {
+	return true
+}
+
+func OnlyMessages(key, value string) bool {
+	if key == "MESSAGE" {
+		return true
+	}
+	return false
 }
 
 // NewJournalReader creates a new JournalReader with configuration options that are similar to the
@@ -131,140 +148,85 @@ func (r *JournalReader) Close() error {
 	return r.journal.Close()
 }
 
-// Follow synchronously follows the JournalReader, writing each new journal entry to writer. The
-// follow will continue until a single time.Time is received on the until channel.
-func (r *JournalReader) Follow(until <-chan time.Time, writer io.Writer) (err error) {
-
-	// Process journal entries and events. Entries are flushed until the tail or
-	// timeout is reached, and then we wait for new events or the timeout.
-	var msg = make([]byte, 64*1<<(10))
-process:
-	for {
-		c, err := r.Read(msg)
-		if err != nil && err != io.EOF {
-			break process
-		}
-
-		select {
-		case <-until:
-			return ErrExpired
-		default:
-			if c > 0 {
-				writer.Write(msg[:c])
-				continue process
-			}
-		}
-
-		// We're at the tail, so wait for new events or time out.
-		// Holds journal events to process. Tightly bounded for now unless there's a
-		// reason to unblock the journal watch routine more quickly.
-		events := make(chan int, 1)
-		pollDone := make(chan bool, 1)
-		go func() {
-			for {
-				select {
-				case <-pollDone:
-					return
-				default:
-					events <- r.journal.Wait(time.Duration(1) * time.Second)
-				}
-			}
-		}()
-
-		select {
-		case <-until:
-			pollDone <- true
-			return ErrExpired
-		case e := <-events:
-			pollDone <- true
-			switch e {
-			case SD_JOURNAL_NOP, SD_JOURNAL_APPEND, SD_JOURNAL_INVALIDATE:
-				// TODO: need to account for any of these?
+// Follow asynchronously follows the JournalReader it takes in a context to stop the following the Journal, it returns a
+// buffered channel of errors and will stop following the journal on the first given error
+func (r *JournalReader) Follow(ctx context.Context, msgs chan<- map[string]interface{}, filter FollowFilter) <-chan error {
+	errChan := make(chan error, 1)
+	go func() {
+		for {
+			kvMap := make(map[string]interface{})
+			select {
+			case <-ctx.Done():
+				errChan <- ctx.Err()
+				return
 			default:
-				log.Printf("Received unknown event: %d\n", e)
-			}
-			continue process
-		}
-	}
+				var err error
+				var c int
 
-	return
-}
+				// Advance the journal cursor
+				c, err = r.journal.Next()
 
-// FollowWithFields synchronously follows the Journal, writing each full Journal Entry with all its given fields
-// as a map to the writer. Similar to Follow(), it will continue until a single time.Time is
-// received on the until channel.
-func (r *JournalReader) FollowWithFields(until <-chan time.Time, writer io.Writer) (err error) {
-	enc := json.NewEncoder(writer)
-journal:
-	for {
-		kvMap := make(map[string]string)
-		select {
-		case <-until:
-			return ErrExpired
-		default:
-			var err error
-			var c int
+				// An unexpected error
+				if err != nil {
+					errChan <- err
+					return
+				}
 
-			// Advance the journal cursor
-			c, err = r.journal.Next()
-
-			// An unexpected error
-			if err != nil {
-				return err
-			}
-
-			// We have a new journal entry go over the fields
-			// get the data for what we care about and return
-			r.journal.RestartData()
-			if c > 0 {
-			fields:
-				for {
-					s, err := r.journal.EnumerateData()
-					if err != nil || len(s) == 0 {
-						break fields
+				// We have a new journal entry go over the fields
+				// get the data for what we care about and return
+				r.journal.RestartData()
+				if c > 0 {
+				fields:
+					for {
+						s, err := r.journal.EnumerateData()
+						if err != nil || len(s) == 0 {
+							break fields
+						}
+						s = s[:len(s)]
+						arr := strings.SplitN(s, "=", 2)
+						// if we want the pair,
+						// add it to the map
+						if filter(arr[0], arr[1]) {
+							kvMap[arr[0]] = arr[1]
+						}
 					}
-					s = s[:len(s)]
-					arr := strings.SplitN(s, "=", 2)
-					kvMap[arr[0]] = arr[1]
-				}
-				if err := enc.Encode(kvMap); err != nil {
-					return err
+					msgs <- kvMap
 				}
 			}
-		}
 
-		// we're at the tail, so wait for new events or time out.
-		// holds journal events to process. tightly bounded for now unless there's a
-		// reason to unblock the journal watch routine more quickly
-		events := make(chan int, 1)
-		pollDone := make(chan bool, 1)
-		go func() {
-			for {
-				select {
-				case <-pollDone:
-					return
+			// we're at the tail, so wait for new events or time out.
+			// holds journal events to process. tightly bounded for now unless there's a
+			// reason to unblock the journal watch routine more quickly
+			events := make(chan int, 1)
+			pollDone := make(chan bool, 1)
+			go func() {
+				for {
+					select {
+					case <-pollDone:
+						return
+					default:
+						events <- r.journal.Wait(time.Duration(1) * time.Second)
+					}
+				}
+			}()
+
+			select {
+			case <-ctx.Done():
+				errChan <- ctx.Err()
+				pollDone <- true
+				return
+			case e := <-events:
+				pollDone <- true
+				switch e {
+				case SD_JOURNAL_NOP, SD_JOURNAL_APPEND, SD_JOURNAL_INVALIDATE:
+					// TODO: need to account for any of these?
 				default:
-					events <- r.journal.Wait(time.Duration(1) * time.Second)
+					log.Printf("Received unknown event: %d\n", e)
 				}
 			}
-		}()
-
-		select {
-		case <-until:
-			pollDone <- true
-			return ErrExpired
-		case e := <-events:
-			pollDone <- true
-			switch e {
-			case SD_JOURNAL_NOP, SD_JOURNAL_APPEND, SD_JOURNAL_INVALIDATE:
-				// TODO: need to account for any of these?
-			default:
-				log.Printf("Received unknown event: %d\n", e)
-			}
-			continue journal
 		}
-	}
-	return
+	}()
+	return errChan
 }
 
 // buildMessage returns a string representing the current journal entry in a simple format which

--- a/sdjournal/read.go
+++ b/sdjournal/read.go
@@ -16,10 +16,12 @@
 package sdjournal
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -185,6 +187,83 @@ process:
 		}
 	}
 
+	return
+}
+
+func (r *JournalReader) FollowWithFields(until <-chan time.Time, fields map[string]struct{}, writer io.Writer) (err error) {
+	enc := json.NewEncoder(writer)
+journal:
+	for {
+		kvMap := make(map[string]string)
+		select {
+		case <-until:
+			return ErrExpired
+		default:
+			var err error
+			var c int
+
+			// Advance the journal cursor
+			c, err = r.journal.Next()
+
+			// An unexpected error
+			if err != nil {
+				return err
+			}
+
+			// We have a new journal entry go over the fields
+			// get the data for what we care about and return
+			r.journal.RestartData()
+			if c > 0 {
+			fields:
+				for {
+					s, err := r.journal.EnumerateData()
+					if err != nil || len(s) == 0 {
+						break fields
+					}
+					s = s[:len(s)]
+					arr := strings.SplitN(s, "=", 2)
+					if _, ok := fields[arr[0]]; ok {
+						kvMap[arr[0]] = arr[1]
+					}
+
+				}
+				if err := enc.Encode(kvMap); err != nil {
+					return err
+				}
+			}
+		}
+
+		// we're at the tail, so wait for new events or time out.
+		// holds journal events to process. tightly bounded for now unless there's a
+		// reason to unblock the journal watch routine more quickly
+		events := make(chan int, 1)
+		pollDone := make(chan bool, 1)
+		go func() {
+			for {
+				select {
+				case <-pollDone:
+					return
+				default:
+					events <- r.journal.Wait(time.Duration(1) * time.Second)
+				}
+			}
+		}()
+
+		select {
+		case <-until:
+			pollDone <- true
+			return ErrExpired
+		case e := <-events:
+			pollDone <- true
+			switch e {
+			case SD_JOURNAL_NOP, SD_JOURNAL_APPEND, SD_JOURNAL_INVALIDATE:
+				// TODO: need to account for any of these?
+			default:
+				log.Printf("Received unknown event: %d\n", e)
+			}
+			continue journal
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
Okay so this is a combination of my last 2 pull requests: #149 and #151 and I think this provides really what an end user would want. 

So let me describe the changes here: 

1) take in a ctx.Context rather than a time.Time

This allows more flexibility in use cases as described here: 

> For example, I am working on a daemon that forwards journald logs to an external logging service over http. The only reason I would ever want it killed is if a signal interrupt were given, so to do this I send a time.Now() from my signal handler into this channel to stop the program gracefully.

If I use a context, its more clear that I want to cancel processing of the logs rather than sending a time. Alternatively if someone wants to finish processing at a certain time, they can still do so. All they would have to do is send a ctx.Done() whenever the time hts

2) Use a filter function to figure out what part of the journald log you want

It's very reasonable for someone to want the entire journal entry, rather than just the message field. In fact, we use the Send() method from the journal library https://github.com/coreos/go-systemd/blob/master/journal/journal.go#L75 to write custom log fields for our programs into journald. It's only suitable that we should be able to pull them out for later processing

3) Send the journal entries with the filtered fields to `msgs chan<- map[string]interface{}`

This allows us to read all fields from the jorunal without worrying about the type and send them asynchronously without having to marshal and unmarshal the entries

Willing to close #151 in favor of this.

Thanks for all the help
