### PR TITLE
Expose dbus.NewConnection

### DIFF
--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -86,7 +86,7 @@ type Conn struct {
 // New establishes a connection to the system bus and authenticates.
 // Callers should call Close() when done with the connection.
 func New() (*Conn, error) {
-	return newConnection(func() (*dbus.Conn, error) {
+	return NewConnection(func() (*dbus.Conn, error) {
 		return dbusAuthHelloConnection(dbus.SystemBusPrivate)
 	})
 }
@@ -95,7 +95,7 @@ func New() (*Conn, error) {
 // authenticates. This can be used to connect to systemd user instances.
 // Callers should call Close() when done with the connection.
 func NewUserConnection() (*Conn, error) {
-	return newConnection(func() (*dbus.Conn, error) {
+	return NewConnection(func() (*dbus.Conn, error) {
 		return dbusAuthHelloConnection(dbus.SessionBusPrivate)
 	})
 }
@@ -104,7 +104,7 @@ func NewUserConnection() (*Conn, error) {
 // This can be used for communicating with systemd without a dbus daemon.
 // Callers should call Close() when done with the connection.
 func NewSystemdConnection() (*Conn, error) {
-	return newConnection(func() (*dbus.Conn, error) {
+	return NewConnection(func() (*dbus.Conn, error) {
 		// We skip Hello when talking directly to systemd.
 		return dbusAuthConnection(func() (*dbus.Conn, error) {
 			return dbus.Dial("unix:path=/run/systemd/private")
@@ -118,13 +118,18 @@ func (c *Conn) Close() {
 	c.sigconn.Close()
 }
 
-func newConnection(createBus func() (*dbus.Conn, error)) (*Conn, error) {
-	sysconn, err := createBus()
+// NewConnection establishes a connection to a bus using a caller-supplied function.
+// This allows connecting to remote buses through a user-supplied mechanism.
+// The supplied function may be called multiple times, and should return independent connections.
+// The returned connection must be fully initialised: the org.freedesktop.DBus.Hello call must have succeeded,
+// and any authentication should be handled by the function.
+func NewConnection(dialBus func() (*dbus.Conn, error)) (*Conn, error) {
+	sysconn, err := dialBus()
 	if err != nil {
 		return nil, err
 	}
 
-	sigconn, err := createBus()
+	sigconn, err := dialBus()
 	if err != nil {
 		sysconn.Close()
 		return nil, err


### PR DESCRIPTION
I'm trying to use the go-systemd/dbus package with DBus sockets established over SSH.
This is mostly a straw PR, since we could probably find a better way of exposing this.