### PR TITLE
sdjournal: fix error mgmt in NewJournalFromDir

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -323,12 +323,13 @@ func NewJournal() (j *Journal, err error) {
 		return nil, err
 	}
 	defer func() {
-		if err == nil {
-			return
-		}
 		err2 := h.Close()
 		if err2 != nil {
-			err = fmt.Errorf(`%q and "error closing handle: %v"`, err, err2)
+			if err != nil {
+				err = fmt.Errorf(`%q and "error closing handle: %v"`, err, err2)
+			} else {
+				err = fmt.Errorf(`error closing handle: %v`, err2)
+			}
 		}
 	}()
 
@@ -357,12 +358,13 @@ func NewJournalFromDir(path string) (j *Journal, err error) {
 		return nil, err
 	}
 	defer func() {
-		if err == nil {
-			return
-		}
 		err2 := h.Close()
 		if err2 != nil {
-			err = fmt.Errorf(`%q and "error closing handle: %v"`, err, err2)
+			if err != nil {
+				err = fmt.Errorf(`%q and "error closing handle: %v"`, err, err2)
+			} else {
+				err = fmt.Errorf(`error closing handle: %v`, err2)
+			}
 		}
 	}()
 


### PR DESCRIPTION
Errors were previously hidden. With this patch, I can see the following
error:

> $ ./client_example
> rpc error: code = 2 desc = "error resolving symbol \"sd_journal_next\": .2: undefined symbol: sd_journal_next"

Reproducible steps on https://github.com/coreos/rkt/issues/2740. This is
not solving the symbol issue, but at least, the error is not hidden.