### PR TITLE
dbus: add PropPids to set initial pids of transient scope units

### DIFF
--- a/dbus/properties.go
+++ b/dbus/properties.go
@@ -216,3 +216,13 @@ func PropSlice(slice string) Property {
 		Value: dbus.MakeVariant(slice),
 	}
 }
+
+// PropPids sets the PIDs field of scope units used in the initial construction
+// of the scope only and specifies the initial PIDs to add to the scope object.
+// See https://www.freedesktop.org/wiki/Software/systemd/ControlGroupInterface/#properties
+func PropPids(pids ...uint32) Property {
+	return Property{
+		Name:  "PIDs",
+		Value: dbus.MakeVariant(pids),
+	}
+}


### PR DESCRIPTION
Should there also be a usage example on how to create a transient scope unit instead of a transient service unit?

Feel free to use https://github.com/mgit-at/systemd-runas/blob/master/main.go as a example on how to use the call with transient scopes.