### PR TITLE
sdjournal: tie libsystemdFunctions to Journal's life

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -240,8 +240,6 @@ import (
 	"github.com/coreos/pkg/dlopen"
 )
 
-var libsystemdFunctions = map[string]unsafe.Pointer{}
-
 // Journal entry field strings which correspond to:
 // http://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html
 const (
@@ -283,9 +281,10 @@ var libsystemdNames = []string{
 
 // Journal is a Go wrapper of an sd_journal structure.
 type Journal struct {
-	cjournal *C.sd_journal
-	mu       sync.Mutex
-	lib      *dlopen.LibHandle
+	cjournal            *C.sd_journal
+	mu                  sync.Mutex
+	lib                 *dlopen.LibHandle
+	libsystemdFunctions map[string]unsafe.Pointer
 }
 
 // Match is a convenience wrapper to describe filters supplied to AddMatch.
@@ -302,7 +301,7 @@ func (m *Match) String() string {
 func (j *Journal) getFunction(name string) (unsafe.Pointer, error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
-	f, ok := libsystemdFunctions[name]
+	f, ok := j.libsystemdFunctions[name]
 	if !ok {
 		var err error
 		f, err = j.lib.GetSymbolPointer(name)
@@ -310,7 +309,7 @@ func (j *Journal) getFunction(name string) (unsafe.Pointer, error) {
 			return nil, err
 		}
 
-		libsystemdFunctions[name] = f
+		j.libsystemdFunctions[name] = f
 	}
 
 	return f, nil
@@ -332,7 +331,7 @@ func NewJournal() (j *Journal, err error) {
 		}
 	}()
 
-	j = &Journal{lib: h}
+	j = &Journal{lib: h, libsystemdFunctions: make(map[string]unsafe.Pointer)}
 
 	sd_journal_open, err := j.getFunction("sd_journal_open")
 	if err != nil {
@@ -371,7 +370,7 @@ func NewJournalFromDir(path string) (j *Journal, err error) {
 		return nil, err
 	}
 
-	j = &Journal{lib: h}
+	j = &Journal{lib: h, libsystemdFunctions: make(map[string]unsafe.Pointer)}
 
 	sd_journal_open_directory, err := j.getFunction("sd_journal_open_directory")
 	if err != nil {


### PR DESCRIPTION
There was a map from function names to their addresses so we don't
need to call dlsym everytime we call a function from libsystemd if it
was already called before.

Every time we open a new Journal, we call dlopen() (and every time we
close it, we call dlclose()). Since the map was global and we weren't
clearing it up after closing Journal, we were reusing the addresses from
the previous invocation. This is wrong because libsystemd can end up in
a different address the second time we dlopen() it.

Store the map in the Journal struct so it's a per-Journal cache.

Should fix https://github.com/coreos/rkt/issues/2740