### PR TITLE
sdjournal: don't close libsystemd on Close()

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -400,7 +400,9 @@ func (j *Journal) Close() error {
 	C.my_sd_journal_close(sd_journal_close, j.cjournal)
 	j.mu.Unlock()
 
-	return j.lib.Close()
+	// we don't close the handle to reuse the symbol cache between Journal
+	// instances. It will go away when the process exits.
+	return nil
 }
 
 // AddMatch adds a match by which to filter the entries of the journal.


### PR DESCRIPTION
There is a symbol cache (map from function names to their addresses) so
we don't need to call dlsym everytime we call a function from libsystemd
if it was already called before.

Every time we open a new Journal, we call dlopen(), and every time we
close it, we call dlclose(). Since the map was global and we weren't
clearing it up after closing Journal, we were reusing the addresses from
the previous invocation. This is wrong because libsystemd can end up in
a different address the second time we dlopen() it.

Instead, just don't call dlclose() when we close the Journal so
libsystemd remains in the process address space for the whole life of
it. This means the symbol cache will be shared between different Journal
instances.

According to dlopen(3):
 
 If the same shared object is loaded again with dlopen(), the
 same object handle is returned. The dynamic linker maintains reference
 counts for object handles, so a dynamically loaded shared object is
 not deallocated until dlclose() has been called on it as many times
 as dlopen() has succeeded on it.

So we don't worry about calling dlopen() on an already opened library.

This is an alternative fix to https://github.com/coreos/go-systemd/pull/169