### PR TITLE
sdjournal: Break the loop if error happens during Write().

### DIFF
--- a/sdjournal/read.go
+++ b/sdjournal/read.go
@@ -161,7 +161,9 @@ process:
 			return ErrExpired
 		default:
 			if c > 0 {
-				writer.Write(msg[:c])
+				if err = writer.Write(msg[:c]); err != nil {
+					break process
+				}
 				continue process
 			}
 		}


### PR DESCRIPTION
This fixes the endless loop issue reported by @alban .

