### PR TITLE
dbus: fix testsuite

### DIFF
--- a/test
+++ b/test
@@ -24,6 +24,7 @@ if [ -z "$GOPATH" ]; then
 	fi
 	export GOPATH=${PWD}/gopath
 	go get -u github.com/godbus/dbus
+	go get -u github.com/coreos/pkg/dlopen
 fi
 
 TESTABLE="activation journal login1 machine1 unit"


### PR DESCRIPTION
Some assumptions do not hold anymore on recent debian-derivatives.
Tests updated to avoid failures in modern dbus/systemd environments.

Fixes #165