### PR TITLE
sdjournal: fix a race in GetEntry test

### DIFF
--- a/sdjournal/journal_test.go
+++ b/sdjournal/journal_test.go
@@ -204,10 +204,7 @@ func TestJournalGetEntry(t *testing.T) {
 		t.Fatalf("Error writing to journal: %s", err)
 	}
 
-	r := j.Wait(time.Duration(1) * time.Second)
-	if r < 0 {
-		t.Fatalf("Error waiting to journal")
-	}
+	time.Sleep(time.Duration(1) * time.Second)
 
 	n, err := j.Next()
 	if err != nil {


### PR DESCRIPTION
Hard-sleep instead of waiting for a journal event.
This fixes a race due to waiting for any events but enumerating only
matching ones.

Closes #180