### PR TITLE
Don't specify NextProtos so that we can take advantage of HTTP/2

### DIFF
--- a/activation/listeners.go
+++ b/activation/listeners.go
@@ -48,8 +48,6 @@ func TLSListeners(unsetEnv bool, tlsConfig *tls.Config) ([]net.Listener, error) 
 	}
 
 	if tlsConfig != nil && err == nil {
-		tlsConfig.NextProtos = []string{"http/1.1"}
-
 		for i, l := range listeners {
 			// Activate TLS only for TCP sockets
 			if l.Addr().Network() == "tcp" {


### PR DESCRIPTION
If we don't specify `NextProtos` HTTP/2 support will be enable when possible. See https://github.com/golang/go/issues/14374#issuecomment-187939699 and https://github.com/golang/go/commit/b5f0aff49503e31002b33198e06708e263c445a7