### PR TITLE
sdjournal: fix memory leak in cursor handling

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -736,6 +736,8 @@ func (j *Journal) GetEntry() (*JournalEntry, error) {
 	entry.MonotonicTimestamp = uint64(monotonicUsec)
 
 	var c *C.char
+	defer C.free(unsafe.Pointer(c))
+
 	r = C.my_sd_journal_get_cursor(sd_journal_get_cursor, j.cjournal, &c)
 	if r < 0 {
 		return nil, fmt.Errorf("failed to get cursor: %d", syscall.Errno(-r))
@@ -834,12 +836,13 @@ func (j *Journal) GetMonotonicUsec() (uint64, error) {
 
 // GetCursor gets the cursor of the current journal entry.
 func (j *Journal) GetCursor() (string, error) {
-	var d *C.char
-
 	sd_journal_get_cursor, err := j.getFunction("sd_journal_get_cursor")
 	if err != nil {
 		return "", err
 	}
+
+	var d *C.char
+	defer C.free(unsafe.Pointer(d))
 
 	j.mu.Lock()
 	r := C.my_sd_journal_get_cursor(sd_journal_get_cursor, j.cjournal, &d)


### PR DESCRIPTION
https://github.com/systemd/systemd/blob/622a0f628cee51851ad00856f9efddedf0799edb/src/journal/sd-journal.c#L936

Since `asprintf`'s `dst` argument has to be freed

Like it's done here: https://github.com/systemd/systemd/blob/29a753df7682424a0ea505698d548f85c514fad5/src/shared/logs-show.c#L471