### PR TITLE
sdjournal: fix race condition in test

### DIFF
--- a/sdjournal/journal_test.go
+++ b/sdjournal/journal_test.go
@@ -59,7 +59,7 @@ func TestJournalFollow(t *testing.T) {
 			case <-done:
 				return
 			default:
-				if err = journal.Print(journal.PriInfo, "test message %s", time.Now()); err != nil {
+				if err := journal.Print(journal.PriInfo, "test message %s", time.Now()); err != nil {
 					t.Fatalf("Error writing to journal: %s", err)
 				}
 


### PR DESCRIPTION
Just a small testfix :smile: 
Probably you should add the `-race` flag to your build script

since the go builtin command  creates a closure, it uses the same err variable than causes race condition in tests

```
go test ./... -race
==================
WARNING: DATA RACE
Write at 0x00c42007a7e0 by goroutine 6:
  github.com/coreos/go-systemd/sdjournal.TestJournalFollow()
      /home/amenzhinsky/Development/go/src/github.com/coreos/go-systemd/sdjournal/journal_test.go:73 +0x323
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:610 +0xc9

Previous write at 0x00c42007a7e0 by goroutine 7:
  github.com/coreos/go-systemd/sdjournal.TestJournalFollow.func1()
      /home/amenzhinsky/Development/go/src/github.com/coreos/go-systemd/sdjournal/journal_test.go:62 +0x176

Goroutine 6 (running) created at:
  testing.(*T).Run()
      /usr/lib/go/src/testing/testing.go:646 +0x52f
  testing.RunTests.func1()
      /usr/lib/go/src/testing/testing.go:793 +0xb9
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:610 +0xc9
  testing.RunTests()
      /usr/lib/go/src/testing/testing.go:799 +0x4ba
  testing.(*M).Run()
      /usr/lib/go/src/testing/testing.go:743 +0x12f
  main.main()
      github.com/coreos/go-systemd/sdjournal/_test/_testmain.go:114 +0x2f8

Goroutine 7 (running) created at:
  github.com/coreos/go-systemd/sdjournal.TestJournalFollow()
      /home/amenzhinsky/Development/go/src/github.com/coreos/go-systemd/sdjournal/journal_test.go:69 +0x29b
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:610 +0xc9
==================
```