### PR TITLE
sdjournal: fix concurent map access

### DIFF
--- a/sdjournal/functions.go
+++ b/sdjournal/functions.go
@@ -1,0 +1,66 @@
+// Copyright 2015 RedHat, Inc.
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdjournal
+
+import (
+	"github.com/coreos/pkg/dlopen"
+	"sync"
+	"unsafe"
+)
+
+var (
+	// lazy initialized
+	libsystemdHandle *dlopen.LibHandle
+
+	libsystemdMutex     = &sync.Mutex{}
+	libsystemdFunctions = map[string]unsafe.Pointer{}
+	libsystemdNames     = []string{
+		// systemd < 209
+		"libsystemd-journal.so.0",
+		"libsystemd-journal.so",
+
+		// systemd >= 209 merged libsystemd-journal into libsystemd proper
+		"libsystemd.so.0",
+		"libsystemd.so",
+	}
+)
+
+func getFunction(name string) (unsafe.Pointer, error) {
+	libsystemdMutex.Lock()
+	defer libsystemdMutex.Unlock()
+
+	if libsystemdHandle == nil {
+		h, err := dlopen.GetHandle(libsystemdNames)
+		if err != nil {
+			return nil, err
+		}
+
+		libsystemdHandle = h
+	}
+
+	f, ok := libsystemdFunctions[name]
+	if !ok {
+		var err error
+		f, err = libsystemdHandle.GetSymbolPointer(name)
+		if err != nil {
+			return nil, err
+		}
+
+		libsystemdFunctions[name] = f
+	}
+
+	return f, nil
+}

--- a/sdjournal/functions_test.go
+++ b/sdjournal/functions_test.go
@@ -1,0 +1,36 @@
+// Copyright 2015 RedHat, Inc.
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdjournal
+
+import "testing"
+
+func TestGetFunction(t *testing.T) {
+	f, err := getFunction("sd_journal_open")
+
+	if err != nil {
+		t.Errorf("Error getting an existing function: %s", err)
+	}
+
+	if f == nil {
+		t.Error("Got nil function pointer")
+	}
+
+	_, err = getFunction("non_existent_function")
+
+	if err == nil {
+		t.Error("Expected to get an error, got nil")
+	}
+}

--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -259,17 +259,12 @@ import "C"
 import (
 	"bytes"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
 	"unsafe"
-
-	"github.com/coreos/pkg/dlopen"
 )
-
-var libsystemdFunctions = map[string]unsafe.Pointer{}
 
 // Journal entry field strings which correspond to:
 // http://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html
@@ -330,21 +325,10 @@ const (
 	IndefiniteWait time.Duration = 1<<63 - 1
 )
 
-var libsystemdNames = []string{
-	// systemd < 209
-	"libsystemd-journal.so.0",
-	"libsystemd-journal.so",
-
-	// systemd >= 209 merged libsystemd-journal into libsystemd proper
-	"libsystemd.so.0",
-	"libsystemd.so",
-}
-
 // Journal is a Go wrapper of an sd_journal structure.
 type Journal struct {
 	cjournal *C.sd_journal
 	mu       sync.Mutex
-	lib      *dlopen.LibHandle
 }
 
 // JournalEntry represents all fields of a journal entry plus address fields.
@@ -366,42 +350,11 @@ func (m *Match) String() string {
 	return m.Field + "=" + m.Value
 }
 
-func (j *Journal) getFunction(name string) (unsafe.Pointer, error) {
-	j.mu.Lock()
-	defer j.mu.Unlock()
-	f, ok := libsystemdFunctions[name]
-	if !ok {
-		var err error
-		f, err = j.lib.GetSymbolPointer(name)
-		if err != nil {
-			return nil, err
-		}
-
-		libsystemdFunctions[name] = f
-	}
-
-	return f, nil
-}
-
 // NewJournal returns a new Journal instance pointing to the local journal
 func NewJournal() (j *Journal, err error) {
-	h, err := dlopen.GetHandle(libsystemdNames)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err == nil {
-			return
-		}
-		err2 := h.Close()
-		if err2 != nil {
-			err = fmt.Errorf(`%q and "error closing handle: %v"`, err, err2)
-		}
-	}()
+	j = &Journal{}
 
-	j = &Journal{lib: h}
-
-	sd_journal_open, err := j.getFunction("sd_journal_open")
+	sd_journal_open, err := getFunction("sd_journal_open")
 	if err != nil {
 		return nil, err
 	}
@@ -419,28 +372,9 @@ func NewJournal() (j *Journal, err error) {
 // in a given directory. The supplied path may be relative or absolute; if
 // relative, it will be converted to an absolute path before being opened.
 func NewJournalFromDir(path string) (j *Journal, err error) {
-	h, err := dlopen.GetHandle(libsystemdNames)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err == nil {
-			return
-		}
-		err2 := h.Close()
-		if err2 != nil {
-			err = fmt.Errorf(`%q and "error closing handle: %v"`, err, err2)
-		}
-	}()
+	j = &Journal{}
 
-	path, err = filepath.Abs(path)
-	if err != nil {
-		return nil, err
-	}
-
-	j = &Journal{lib: h}
-
-	sd_journal_open_directory, err := j.getFunction("sd_journal_open_directory")
+	sd_journal_open_directory, err := getFunction("sd_journal_open_directory")
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +392,7 @@ func NewJournalFromDir(path string) (j *Journal, err error) {
 
 // Close closes a journal opened with NewJournal.
 func (j *Journal) Close() error {
-	sd_journal_close, err := j.getFunction("sd_journal_close")
+	sd_journal_close, err := getFunction("sd_journal_close")
 	if err != nil {
 		return err
 	}
@@ -467,14 +401,12 @@ func (j *Journal) Close() error {
 	C.my_sd_journal_close(sd_journal_close, j.cjournal)
 	j.mu.Unlock()
 
-	// we don't close the handle to reuse the symbol cache between Journal
-	// instances. It will go away when the process exits.
 	return nil
 }
 
 // AddMatch adds a match by which to filter the entries of the journal.
 func (j *Journal) AddMatch(match string) error {
-	sd_journal_add_match, err := j.getFunction("sd_journal_add_match")
+	sd_journal_add_match, err := getFunction("sd_journal_add_match")
 	if err != nil {
 		return err
 	}
@@ -495,7 +427,7 @@ func (j *Journal) AddMatch(match string) error {
 
 // AddDisjunction inserts a logical OR in the match list.
 func (j *Journal) AddDisjunction() error {
-	sd_journal_add_disjunction, err := j.getFunction("sd_journal_add_disjunction")
+	sd_journal_add_disjunction, err := getFunction("sd_journal_add_disjunction")
 	if err != nil {
 		return err
 	}
@@ -513,7 +445,7 @@ func (j *Journal) AddDisjunction() error {
 
 // AddConjunction inserts a logical AND in the match list.
 func (j *Journal) AddConjunction() error {
-	sd_journal_add_conjunction, err := j.getFunction("sd_journal_add_conjunction")
+	sd_journal_add_conjunction, err := getFunction("sd_journal_add_conjunction")
 	if err != nil {
 		return err
 	}
@@ -531,7 +463,7 @@ func (j *Journal) AddConjunction() error {
 
 // FlushMatches flushes all matches, disjunctions and conjunctions.
 func (j *Journal) FlushMatches() {
-	sd_journal_flush_matches, err := j.getFunction("sd_journal_flush_matches")
+	sd_journal_flush_matches, err := getFunction("sd_journal_flush_matches")
 	if err != nil {
 		return
 	}
@@ -543,7 +475,7 @@ func (j *Journal) FlushMatches() {
 
 // Next advances the read pointer into the journal by one entry.
 func (j *Journal) Next() (int, error) {
-	sd_journal_next, err := j.getFunction("sd_journal_next")
+	sd_journal_next, err := getFunction("sd_journal_next")
 	if err != nil {
 		return -1, err
 	}
@@ -562,7 +494,7 @@ func (j *Journal) Next() (int, error) {
 // NextSkip advances the read pointer by multiple entries at once,
 // as specified by the skip parameter.
 func (j *Journal) NextSkip(skip uint64) (uint64, error) {
-	sd_journal_next_skip, err := j.getFunction("sd_journal_next_skip")
+	sd_journal_next_skip, err := getFunction("sd_journal_next_skip")
 	if err != nil {
 		return 0, err
 	}
@@ -580,7 +512,7 @@ func (j *Journal) NextSkip(skip uint64) (uint64, error) {
 
 // Previous sets the read pointer into the journal back by one entry.
 func (j *Journal) Previous() (uint64, error) {
-	sd_journal_previous, err := j.getFunction("sd_journal_previous")
+	sd_journal_previous, err := getFunction("sd_journal_previous")
 	if err != nil {
 		return 0, err
 	}
@@ -599,7 +531,7 @@ func (j *Journal) Previous() (uint64, error) {
 // PreviousSkip sets back the read pointer by multiple entries at once,
 // as specified by the skip parameter.
 func (j *Journal) PreviousSkip(skip uint64) (uint64, error) {
-	sd_journal_previous_skip, err := j.getFunction("sd_journal_previous_skip")
+	sd_journal_previous_skip, err := getFunction("sd_journal_previous_skip")
 	if err != nil {
 		return 0, err
 	}
@@ -616,7 +548,7 @@ func (j *Journal) PreviousSkip(skip uint64) (uint64, error) {
 }
 
 func (j *Journal) getData(field string) (unsafe.Pointer, C.int, error) {
-	sd_journal_get_data, err := j.getFunction("sd_journal_get_data")
+	sd_journal_get_data, err := getFunction("sd_journal_get_data")
 	if err != nil {
 		return nil, 0, err
 	}
@@ -686,27 +618,27 @@ func (j *Journal) GetDataValueBytes(field string) ([]byte, error) {
 // all key-value pairs of data as well as address fields (cursor, realtime
 // timestamp and monotonic timestamp)
 func (j *Journal) GetEntry() (*JournalEntry, error) {
-	sd_journal_get_realtime_usec, err := j.getFunction("sd_journal_get_realtime_usec")
+	sd_journal_get_realtime_usec, err := getFunction("sd_journal_get_realtime_usec")
 	if err != nil {
 		return nil, err
 	}
 
-	sd_journal_get_monotonic_usec, err := j.getFunction("sd_journal_get_monotonic_usec")
+	sd_journal_get_monotonic_usec, err := getFunction("sd_journal_get_monotonic_usec")
 	if err != nil {
 		return nil, err
 	}
 
-	sd_journal_get_cursor, err := j.getFunction("sd_journal_get_cursor")
+	sd_journal_get_cursor, err := getFunction("sd_journal_get_cursor")
 	if err != nil {
 		return nil, err
 	}
 
-	sd_journal_restart_data, err := j.getFunction("sd_journal_restart_data")
+	sd_journal_restart_data, err := getFunction("sd_journal_restart_data")
 	if err != nil {
 		return nil, err
 	}
 
-	sd_journal_enumerate_data, err := j.getFunction("sd_journal_enumerate_data")
+	sd_journal_enumerate_data, err := getFunction("sd_journal_enumerate_data")
 	if err != nil {
 		return nil, err
 	}
@@ -777,7 +709,7 @@ func (j *Journal) GetEntry() (*JournalEntry, error) {
 // turned off by setting it to 0, so that the library always returns the
 // complete data objects.
 func (j *Journal) SetDataThreshold(threshold uint64) error {
-	sd_journal_set_data_threshold, err := j.getFunction("sd_journal_set_data_threshold")
+	sd_journal_set_data_threshold, err := getFunction("sd_journal_set_data_threshold")
 	if err != nil {
 		return err
 	}
@@ -798,7 +730,7 @@ func (j *Journal) SetDataThreshold(threshold uint64) error {
 func (j *Journal) GetRealtimeUsec() (uint64, error) {
 	var usec C.uint64_t
 
-	sd_journal_get_realtime_usec, err := j.getFunction("sd_journal_get_realtime_usec")
+	sd_journal_get_realtime_usec, err := getFunction("sd_journal_get_realtime_usec")
 	if err != nil {
 		return 0, err
 	}
@@ -819,7 +751,7 @@ func (j *Journal) GetMonotonicUsec() (uint64, error) {
 	var usec C.uint64_t
 	var boot_id C.sd_id128_t
 
-	sd_journal_get_monotonic_usec, err := j.getFunction("sd_journal_get_monotonic_usec")
+	sd_journal_get_monotonic_usec, err := getFunction("sd_journal_get_monotonic_usec")
 	if err != nil {
 		return 0, err
 	}
@@ -837,7 +769,7 @@ func (j *Journal) GetMonotonicUsec() (uint64, error) {
 
 // GetCursor gets the cursor of the current journal entry.
 func (j *Journal) GetCursor() (string, error) {
-	sd_journal_get_cursor, err := j.getFunction("sd_journal_get_cursor")
+	sd_journal_get_cursor, err := getFunction("sd_journal_get_cursor")
 	if err != nil {
 		return "", err
 	}
@@ -863,7 +795,7 @@ func (j *Journal) GetCursor() (string, error) {
 // TestCursor checks whether the current position in the journal matches the
 // specified cursor
 func (j *Journal) TestCursor(cursor string) error {
-	sd_journal_test_cursor, err := j.getFunction("sd_journal_test_cursor")
+	sd_journal_test_cursor, err := getFunction("sd_journal_test_cursor")
 	if err != nil {
 		return err
 	}
@@ -885,7 +817,7 @@ func (j *Journal) TestCursor(cursor string) error {
 // SeekHead seeks to the beginning of the journal, i.e. the oldest available
 // entry.
 func (j *Journal) SeekHead() error {
-	sd_journal_seek_head, err := j.getFunction("sd_journal_seek_head")
+	sd_journal_seek_head, err := getFunction("sd_journal_seek_head")
 	if err != nil {
 		return err
 	}
@@ -904,7 +836,7 @@ func (j *Journal) SeekHead() error {
 // SeekTail may be used to seek to the end of the journal, i.e. the most recent
 // available entry.
 func (j *Journal) SeekTail() error {
-	sd_journal_seek_tail, err := j.getFunction("sd_journal_seek_tail")
+	sd_journal_seek_tail, err := getFunction("sd_journal_seek_tail")
 	if err != nil {
 		return err
 	}
@@ -923,7 +855,7 @@ func (j *Journal) SeekTail() error {
 // SeekRealtimeUsec seeks to the entry with the specified realtime (wallclock)
 // timestamp, i.e. CLOCK_REALTIME.
 func (j *Journal) SeekRealtimeUsec(usec uint64) error {
-	sd_journal_seek_realtime_usec, err := j.getFunction("sd_journal_seek_realtime_usec")
+	sd_journal_seek_realtime_usec, err := getFunction("sd_journal_seek_realtime_usec")
 	if err != nil {
 		return err
 	}
@@ -941,7 +873,7 @@ func (j *Journal) SeekRealtimeUsec(usec uint64) error {
 
 // SeekCursor seeks to a concrete journal cursor.
 func (j *Journal) SeekCursor(cursor string) error {
-	sd_journal_seek_cursor, err := j.getFunction("sd_journal_seek_cursor")
+	sd_journal_seek_cursor, err := getFunction("sd_journal_seek_cursor")
 	if err != nil {
 		return err
 	}
@@ -967,7 +899,7 @@ func (j *Journal) SeekCursor(cursor string) error {
 func (j *Journal) Wait(timeout time.Duration) int {
 	var to uint64
 
-	sd_journal_wait, err := j.getFunction("sd_journal_wait")
+	sd_journal_wait, err := getFunction("sd_journal_wait")
 	if err != nil {
 		return -1
 	}
@@ -991,7 +923,7 @@ func (j *Journal) Wait(timeout time.Duration) int {
 func (j *Journal) GetUsage() (uint64, error) {
 	var out C.uint64_t
 
-	sd_journal_get_usage, err := j.getFunction("sd_journal_get_usage")
+	sd_journal_get_usage, err := getFunction("sd_journal_get_usage")
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
libsystemdFunctions is shared between Journal instances that can cause
concurrency issues when multiple objects modify it at the same time

```
fatal error: concurrent map writes

goroutine 10 [running]:
runtime.throw(0x4b9623, 0x15)
	/usr/lib/go/src/runtime/panic.go:566 +0x95 fp=0xc420028598 sp=0xc420028578
runtime.mapassign1(0x4a0a80, 0xc420014300, 0xc4200286c8, 0xc4200286c0)
	/usr/lib/go/src/runtime/hashmap.go:458 +0x8ef fp=0xc420028680 sp=0xc420028598
github.com/coreos/go-systemd/sdjournal.(*Journal).getFunction(0xc4200fe020, 0x4b863e, 0xf, 0x0, 0x0, 0x0)
````

Code to reproduce the issue:
```go
package main

import (
	"github.com/coreos/go-systemd/sdjournal"
	"sync"
)

func main() {
	wg := sync.WaitGroup{}
	wg.Add(10)

	for i := 0; i < 10; i++ {
		go func() {
			j, err := sdjournal.NewJournal()

			if err != nil {
				panic(err)
			}

			if _, err = j.Next(); err != nil {
				panic(err)
			}

			for k := 0; k < 1000; k++ {
				if _, err = j.GetEntry(); err != nil {
					panic(err)
				}

			}

			wg.Done()
		}()
	}

	wg.Wait()
}
```

I decided to apply singleton pattern for the libsystemd functions and move then to a separate file.
What do you think?