### PR TITLE
Syntax highlight activation readme

### DIFF
--- a/examples/activation/httpserver/README.md
+++ b/examples/activation/httpserver/README.md
@@ -8,7 +8,7 @@ To try it out `go get` the httpserver and run it under the systemd-activate help
 ```bash
 export GOPATH="$PWD"
 go get github.com/coreos/go-systemd/examples/activation/httpserver
-sudo /usr/lib/systemd/systemd-activate -l 127.0.0.1:8076 ./bin/httpserver
+/usr/lib/systemd/systemd-activate -l 127.0.0.1:8076 ./bin/httpserver
 ```
 
 Then curl the URL and you will notice that it starts up:

--- a/examples/activation/httpserver/README.md
+++ b/examples/activation/httpserver/README.md
@@ -5,8 +5,8 @@ simple HTTP server on http://127.0.0.1:8076
 
 To try it out `go get` the httpserver and run it under the systemd-activate helper
 
-```
-export GOPATH=`pwd`
+```bash
+export GOPATH="$PWD"
 go get github.com/coreos/go-systemd/examples/activation/httpserver
 sudo /usr/lib/systemd/systemd-activate -l 127.0.0.1:8076 ./bin/httpserver
 ```


### PR DESCRIPTION
Two really minor changes:
 * add syntax highlighting for the bash example in the activation readme
 * fix a really pedantic quoting issue when setting `GOPATH`