### PR TITLE
dbus/properties: service type

### DIFF
--- a/dbus/properties.go
+++ b/dbus/properties.go
@@ -78,6 +78,15 @@ func PropRemainAfterExit(b bool) Property {
 	}
 }
 
+// PropType sets the Type service property. See
+// http://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=
+func PropType(t string) Property {
+	return Property{
+		Name:  "Type",
+		Value: dbus.MakeVariant(t),
+	}
+}
+
 // PropDescription sets the Description unit property. See
 // http://www.freedesktop.org/software/systemd/man/systemd.unit#Description=
 func PropDescription(desc string) Property {


### PR DESCRIPTION
`PropType()` sets the Type property

I need to set the service `Type` to test this feature https://github.com/coreos/rkt/pull/2826
See also issue: https://github.com/coreos/rkt/issues/3198