### PR TITLE
sdjournal: fix return values type

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -474,10 +474,10 @@ func (j *Journal) FlushMatches() {
 }
 
 // Next advances the read pointer into the journal by one entry.
-func (j *Journal) Next() (int, error) {
+func (j *Journal) Next() (uint64, error) {
 	sd_journal_next, err := getFunction("sd_journal_next")
 	if err != nil {
-		return -1, err
+		return 0, err
 	}
 
 	j.mu.Lock()
@@ -485,10 +485,10 @@ func (j *Journal) Next() (int, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return int(r), fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
+		return 0, fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
 	}
 
-	return int(r), nil
+	return uint64(r), nil
 }
 
 // NextSkip advances the read pointer by multiple entries at once,
@@ -504,7 +504,7 @@ func (j *Journal) NextSkip(skip uint64) (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return uint64(r), fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
+		return 0, fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
 	}
 
 	return uint64(r), nil
@@ -522,7 +522,7 @@ func (j *Journal) Previous() (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return uint64(r), fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
+		return 0, fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
 	}
 
 	return uint64(r), nil
@@ -541,7 +541,7 @@ func (j *Journal) PreviousSkip(skip uint64) (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return uint64(r), fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
+		return 0, fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
 	}
 
 	return uint64(r), nil

--- a/sdjournal/read.go
+++ b/sdjournal/read.go
@@ -121,7 +121,7 @@ func (r *JournalReader) Read(b []byte) (int, error) {
 	var err error
 
 	if r.msgReader == nil {
-		var c int
+		var c uint64
 
 		// Advance the journal cursor. It has to be called at least one time
 		// before reading


### PR DESCRIPTION
fix inconsistency in return types for journal functions: `NextSkip`,
`Previous`, `PreviousSkip`. Currently they will return (uint64, error),
however according to `sd-journal.h` it should be (int, error)

Journal.Next returns (int, error)
Journal.Previous returns (uint64, error)

https://github.com/systemd/systemd/blob/master/src/systemd/sd-journal.h#L98