### PR TITLE
dbus: make New() fall back to direct systemd connection

### DIFF
--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -83,9 +83,19 @@ type Conn struct {
 	}
 }
 
-// New establishes a connection to the system bus and authenticates.
+// New establishes a connection to any available bus and authenticates.
 // Callers should call Close() when done with the connection.
 func New() (*Conn, error) {
+	conn, err := NewSystemConnection()
+	if err != nil && os.Geteuid() == 0 {
+		return NewSystemdConnection()
+	}
+	return conn, err
+}
+
+// NewSystemConnection establishes a connection to the system bus and authenticates.
+// Callers should call Close() when done with the connection
+func NewSystemConnection() (*Conn, error) {
 	return NewConnection(func() (*dbus.Conn, error) {
 		return dbusAuthHelloConnection(dbus.SystemBusPrivate)
 	})


### PR DESCRIPTION
This matches the logic in systemd - connect to the private socket first,
if running as root. Fall back to the standard system DBus otherwise.

Fixes: #207