### PR TITLE
daemon: add watchdog checker

### DIFF
--- a/daemon/watchdog.go
+++ b/daemon/watchdog.go
@@ -1,0 +1,58 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// SdWatchdogEnabled return watchdog information for a service.
+// Process should send daemon.SdNotify("WATCHDOG=1") every time / 2.
+//
+// It returns one of the following:
+// (0, nil) - watchdog isn't enabled or we aren't the watched PID.
+// (0, err) - an error happened (e.g. error converting time).
+// (time, nil) - watchdog is enabled and we can send ping.
+//   time is delay before inactive service will be killed.
+func SdWatchdogEnabled() (time.Duration, error) {
+	wusec := os.Getenv("WATCHDOG_USEC")
+	if wusec == "" {
+		return 0, nil
+	}
+	s, err := strconv.Atoi(wusec)
+	if err != nil {
+		return 0, fmt.Errorf("error converting WATCHDOG_USEC: %s", err)
+	}
+	if s <= 0 {
+		return 0, fmt.Errorf("error WATCHDOG_USEC must a positive number")
+	}
+
+	wpid := os.Getenv("WATCHDOG_PID")
+	if wpid == "" {
+		return 0, nil
+	}
+	p, err := strconv.Atoi(wpid)
+	if err != nil {
+		return 0, fmt.Errorf("error converting WATCHDOG_PID: %s", err)
+	}
+	if os.Getpid() != p {
+		return 0, nil
+	}
+
+	return time.Duration(s) * time.Microsecond, nil
+}

--- a/daemon/watchdog_test.go
+++ b/daemon/watchdog_test.go
@@ -1,0 +1,122 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemon
+
+import (
+	"os"
+	"strconv"
+	"testing"
+)
+
+func TestSdWatchdogEnabled(t *testing.T) {
+	// (time, nil)
+	err := os.Setenv("WATCHDOG_USEC", "100")
+	if err != nil {
+		panic(err)
+	}
+	err = os.Setenv("WATCHDOG_PID", strconv.Itoa(os.Getpid()))
+	if err != nil {
+		panic(err)
+	}
+
+	delay, err := SdWatchdogEnabled()
+	if delay == 0 || err != nil {
+		t.Errorf("TEST: Watchdog enabled FAILED")
+	}
+
+	// (0, nil) PID doesnt match
+	err = os.Setenv("WATCHDOG_USEC", "100")
+	if err != nil {
+		panic(err)
+	}
+	err = os.Setenv("WATCHDOG_PID", "0")
+	if err != nil {
+		panic(err)
+	}
+	delay, err = SdWatchdogEnabled()
+	if delay != 0 || err != nil {
+		t.Errorf("TEST: PID doesn't match FAILED")
+	}
+
+	// (0, nil) WATCHDOG_USEC doen't exist
+	err = os.Unsetenv("WATCHDOG_USEC")
+	if err != nil {
+		panic(err)
+	}
+	err = os.Setenv("WATCHDOG_PID", strconv.Itoa(os.Getpid()))
+	if err != nil {
+		panic(err)
+	}
+	delay, err = SdWatchdogEnabled()
+	if delay != 0 || err != nil {
+		t.Errorf("TEST: WATCHDOG_USEC doen't exist FAILED")
+	}
+
+	// (0, nil) WATCHDOG_PID doen't exist
+	err = os.Setenv("WATCHDOG_USEC", "1")
+	if err != nil {
+		panic(err)
+	}
+	err = os.Unsetenv("WATCHDOG_PID")
+	if err != nil {
+		panic(err)
+	}
+	delay, err = SdWatchdogEnabled()
+	if delay != 0 || err != nil {
+		t.Errorf("TEST: WATCHDOG_PID doen't exist FAILED")
+	}
+
+	// (0, err) USEC negative
+	err = os.Setenv("WATCHDOG_USEC", "-1")
+	if err != nil {
+		panic(err)
+	}
+	err = os.Setenv("WATCHDOG_PID", strconv.Itoa(os.Getpid()))
+	if err != nil {
+		panic(err)
+	}
+	_, err = SdWatchdogEnabled()
+	if err == nil {
+		t.Errorf("TEST: USEC negative FAILED")
+	}
+
+	// (0, err) Bad USEC
+	err = os.Setenv("WATCHDOG_USEC", "string")
+	if err != nil {
+		panic(err)
+	}
+	err = os.Setenv("WATCHDOG_PID", strconv.Itoa(os.Getpid()))
+	if err != nil {
+		panic(err)
+	}
+	_, err = SdWatchdogEnabled()
+	if err == nil {
+		t.Errorf("TEST: Bad USEC FAILED")
+	}
+
+	// (0, err) Bad PID
+	err = os.Setenv("WATCHDOG_USEC", "1")
+	if err != nil {
+		panic(err)
+	}
+	err = os.Setenv("WATCHDOG_PID", "string")
+	if err != nil {
+		panic(err)
+	}
+	_, err = SdWatchdogEnabled()
+	if err == nil {
+		t.Errorf("TEST: Bad PID FAILED")
+	}
+}


### PR DESCRIPTION
Add a function `SdWatchdogEnabled()` who check if service have to report its status
This is inspirated from the behavior of `sd_watchdog_enabled`