### PR TITLE
daemon: introduce support for cleaning env variables

### DIFF
--- a/daemon/sdnotify.go
+++ b/daemon/sdnotify.go
@@ -22,11 +22,14 @@ import (
 )
 
 // SdNotify sends a message to the init daemon. It is common to ignore the error.
+// If `unsetEnvironment` is true, the environment variable `NOTIFY_SOCKET`
+// will be unconditionally unset.
+//
 // It returns one of the following:
 // (false, nil) - notification not supported (i.e. NOTIFY_SOCKET is unset)
 // (false, err) - notification supported, but failure happened (e.g. error connecting to NOTIFY_SOCKET or while sending data)
 // (true, nil) - notification supported, data has been sent
-func SdNotify(state string) (sent bool, err error) {
+func SdNotify(unsetEnvironment bool, state string) (sent bool, err error) {
 	socketAddr := &net.UnixAddr{
 		Name: os.Getenv("NOTIFY_SOCKET"),
 		Net:  "unixgram",
@@ -35,6 +38,13 @@ func SdNotify(state string) (sent bool, err error) {
 	// NOTIFY_SOCKET not set
 	if socketAddr.Name == "" {
 		return false, nil
+	}
+
+	if unsetEnvironment {
+		err = os.Unsetenv("NOTIFY_SOCKET")
+	}
+	if err != nil {
+		return false, err
 	}
 
 	conn, err := net.DialUnix(socketAddr.Net, nil, socketAddr)

--- a/daemon/watchdog.go
+++ b/daemon/watchdog.go
@@ -39,12 +39,13 @@ func SdWatchdogEnabled() (time.Duration, error) {
 		return 0, fmt.Errorf("error converting WATCHDOG_USEC: %s", err)
 	}
 	if s <= 0 {
-		return 0, fmt.Errorf("error WATCHDOG_USEC must a positive number")
+		return 0, fmt.Errorf("error WATCHDOG_USEC must be a positive number")
 	}
+	interval := time.Duration(s) * time.Microsecond
 
 	wpid := os.Getenv("WATCHDOG_PID")
 	if wpid == "" {
-		return 0, nil
+		return interval, nil
 	}
 	p, err := strconv.Atoi(wpid)
 	if err != nil {
@@ -54,5 +55,5 @@ func SdWatchdogEnabled() (time.Duration, error) {
 		return 0, nil
 	}
 
-	return time.Duration(s) * time.Microsecond, nil
+	return interval, nil
 }

--- a/daemon/watchdog_test.go
+++ b/daemon/watchdog_test.go
@@ -40,10 +40,10 @@ func TestSdWatchdogEnabled(t *testing.T) {
 		{"100", mypid, false, 100 * time.Microsecond},
 		{"50", mypid, false, 50 * time.Microsecond},
 		{"1", mypid, false, 1 * time.Microsecond},
+		{"1", "", false, 1 * time.Microsecond},
 
 		// No-op cases
 		{"", mypid, false, 0}, // WATCHDOG_USEC not set
-		{"1", "", false, 0},   // WATCHDOG_PID not set
 		{"1", "0", false, 0},  // WATCHDOG_PID doesn't match
 		{"", "", false, 0},    // Both not set
 


### PR DESCRIPTION
This fixes `SdWatchdogEnabled()` behavior when `$WATCHDOG_PID` is unset,
and introduces a new `unsetEnvironment` boolean flag to `SdWatchdogEnabled()`
and `SdNotify()` to clear releveant env variables, aligning to the behavior of native methods.