### PR TITLE
travis: set language to shell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: shell # We do everything inside Docker and don't want travis fiddling with steps or environment variables
+
 sudo: required
 
 services:


### PR DESCRIPTION
Travis otherwise seems to think this is a Ruby project, and setting it to a Go project just confuses things, because everything we do is inside Docker containers. 