### PR TITLE
journal: detect space error inside os.SyscallError

### DIFF
--- a/journal/journal.go
+++ b/journal/journal.go
@@ -152,7 +152,13 @@ func isSocketSpaceError(err error) bool {
 		return false
 	}
 
-	sysErr, ok := opErr.Err.(syscall.Errno)
+	// The syscall.Errno can be nested inside an os.SyscallError, or not.
+	maybeErrnoError := opErr.Err
+	if osSyscallErr, ok := opErr.Err.(*os.SyscallError); ok {
+		maybeErrnoError = osSyscallErr.Err
+	}
+
+	sysErr, ok := maybeErrnoError.(syscall.Errno)
 	if !ok {
 		return false
 	}


### PR DESCRIPTION
This changed in Go 1.5 in https://github.com/golang/go/commit/055ecb7b