### PR TITLE
test: Specify periodic go-systemd builder job as dsl

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,33 @@
+matrixJob('Periodic go-systemd builder from dsl') {
+    label('master')
+    displayName('Periodic go-systemd builder (master branch) from dsl')
+
+    scm {
+        git ('https://github.com/coreos/go-systemd.git', '*/master')
+    }
+
+    concurrentBuild()
+
+    triggers {
+        cron('@daily')
+    }
+
+    axes {
+        label('os_type', 'debian-testing', 'fedora-24', 'fedora-25')
+    }
+
+    wrappers {
+        buildNameSetter {
+            template('go-systemd master (periodic #${BUILD_NUMBER})')
+            runAtStart(true)
+            runAtEnd(true)
+        }
+        timeout {
+            absolute(25)
+        }
+    }
+
+    steps {
+        shell('./scripts/jenkins/go-systemd-master.sh')
+    }
+}

--- a/scripts/jenkins/periodic-go-systemd-builder.sh
+++ b/scripts/jenkins/periodic-go-systemd-builder.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo ""
+echo "Public IP: "`wget -O - http://checkip.amazonaws.com/ 2>/dev/null || true`
+echo "Systemd version: "`systemctl --version || true`
+echo "Linux version: "`uname -srm || true`
+echo "Distribution version: "`(. /etc/os-release ; echo $PRETTY_NAME) || true`
+echo ""
+echo "git commit: "`git describe --abbrev=40 HEAD || true`
+echo ""
+
+# unsquashfs is in /usr/sbin
+export PATH=/usr/lib64/ccache:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/home/fedora/.local/bin:/home/fedora/bin
+
+# As a convenience, set up a self-contained GOPATH if none set
+if [ ! -h gopath/src/github.com/coreos/go-systemd ]; then
+    mkdir -p gopath/src/github.com/coreos
+    ln -s ../../../.. gopath/src/github.com/coreos/go-systemd || exit 255
+fi
+export GOPATH=${PWD}/gopath
+go get -u github.com/godbus/dbus
+go get github.com/coreos/pkg/dlopen
+
+sudo -E ./test


### PR DESCRIPTION
Instead of configuring the 'Periodic go-systemd builder' Jenkins job in
the Jenkins-UI this commit introduces the job specification via Jenkins
job dsl language.