### PR TITLE
sdjournal: fix Wait() timeout

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -946,7 +946,7 @@ func (j *Journal) Wait(timeout time.Duration) int {
 		// equivalent hex value.
 		to = 0xffffffffffffffff
 	} else {
-		to = uint64(time.Now().Add(timeout).Unix() / 1000)
+		to = uint64(timeout / time.Microsecond)
 	}
 	j.mu.Lock()
 	r := C.my_sd_journal_wait(sd_journal_wait, j.cjournal, C.uint64_t(to))


### PR DESCRIPTION
This fixes a bug in the Wait() method on sdjournal.Journal{}.
The C API expects a duration in microseconds. However the method was passing a nonsense value (timeout's absolute time as thousands of seconds since epoch). This resulted in the value being capped to a maximum of 1.5s.

Looks like the bug was introduced here: https://github.com/coreos/go-systemd/commit/31020344488513bba6094ac4bd728c8d7f768194#diff-985ded8023b21268d0d5cf7f29781d2eR203

Fixes https://github.com/coreos/go-systemd/issues/145