### PR TITLE
sdjournal: support testing cursor against current position

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -303,6 +303,7 @@ package sdjournal
 import "C"
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -368,6 +369,12 @@ const (
 	// events. It is implemented as the maximum value for a time.Duration:
 	// https://github.com/golang/go/blob/e4dcf5c8c22d98ac9eac7b9b226596229624cb1d/src/time/time.go#L434
 	IndefiniteWait time.Duration = 1<<63 - 1
+)
+
+var (
+	// Error show when using TestCursor function and cursor parameter is not the same
+	// as the current cursor position
+	ErrNoTestCursor = errors.New("Cursor parameter is not the same as current position")
 )
 
 // Journal is a Go wrapper of an sd_journal structure.
@@ -879,6 +886,8 @@ func (j *Journal) TestCursor(cursor string) error {
 
 	if r < 0 {
 		return fmt.Errorf("failed to test to cursor %q: %d", cursor, syscall.Errno(-r))
+	} else if r == 0 {
+		return ErrNoTestCursor
 	}
 
 	return nil

--- a/sdjournal/journal_test.go
+++ b/sdjournal/journal_test.go
@@ -178,6 +178,20 @@ func TestJournalCursorGetSeekAndTest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error testing cursor to journal: %s", err)
 	}
+
+	err = journal.Print(journal.PriInfo, "second message %s", time.Now())
+	if err != nil {
+		t.Fatalf("Error writing to journal: %s", err)
+	}
+
+	if err = waitAndNext(j); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	err = j.TestCursor(c)
+	if err != ErrNoTestCursor {
+		t.Fatalf("Error, TestCursor should fail because current cursor has moved from the previous obtained cursor")
+	}
 }
 
 func TestNewJournalFromDir(t *testing.T) {


### PR DESCRIPTION
This fixes TestCursor so it returns an error when the ``cursor``
parameter is not the same as the current position.

From SD_JOURNAL_GET_CURSOR(3):
```
sd_journal_test_cursor() returns positive if the current entry
matches the specified cursor, 0 if it does not match the specified
cursor or a negative errno-style error code on failure.
```