### PR TITLE
dbus: fix subStateSubscriber crash

### DIFF
--- a/dbus/subscription.go
+++ b/dbus/subscription.go
@@ -175,15 +175,15 @@ func (c *Conn) SetSubStateSubscriber(updateCh chan<- *SubStateUpdate, errCh chan
 	c.subscriber.errCh = errCh
 }
 
-func (c *Conn) sendSubStateUpdate(path dbus.ObjectPath) {
+func (c *Conn) sendSubStateUpdate(unitPath dbus.ObjectPath) {
 	c.subscriber.Lock()
 	defer c.subscriber.Unlock()
 
-	if c.shouldIgnore(path) {
+	if c.shouldIgnore(unitPath) {
 		return
 	}
 
-	info, err := c.GetUnitProperties(string(path))
+	info, err := c.GetUnitPathProperties(unitPath)
 	if err != nil {
 		select {
 		case c.subscriber.errCh <- err:
@@ -204,7 +204,7 @@ func (c *Conn) sendSubStateUpdate(path dbus.ObjectPath) {
 		}
 	}
 
-	c.updateIgnore(path, info)
+	c.updateIgnore(unitPath, info)
 }
 
 // The ignore functions work around a wart in the systemd dbus interface.


### PR DESCRIPTION
When dispatching updates to sub-state subscribers, `sendSubStateUpdate`
previously called `GetUnitProperties` with a full, escaped unit path.
`getUnitProperties` expected only an unescaped unit name.

This commit changes `getUnitProperties` to take the full, escaped path,
updates `GetUnitProperties` to escape and expand the unit name to a
path, and adds `GetUnitPathProperties` for callers who already have the
full, escaped unit path.


To quickly see the problem, run this go program:
```
package main

import (
        "fmt"
        "github.com/coreos/go-systemd/dbus"
)

func main() {
        conn, _ := dbus.New()
        defer conn.Close()

        subUpdateCh := make(chan *dbus.SubStateUpdate)
        subErrCh := make(chan error)
        conn.SetSubStateSubscriber(subUpdateCh, subErrCh)

        for {
                select {
                case subStateUpdate := <-subUpdateCh:
                        fmt.Printf("%+v", subStateUpdate)
                case subStateErr := <-subErrCh:
                        fmt.Printf("error: %v", subStateErr)
                }
        }
}
```

With this program running, do something that updates a systemd unit. For example, if I run `sudo systemctl restart cron.service`, then I see the following output.

*With PR:*
```
&{UnitName:cron.service SubState:running}
```

*Without PR:*
```
panic: interface conversion: interface {} is nil, not string

goroutine 19 [running]:
github.com/coreos/go-systemd/dbus.(*Conn).sendSubStateUpdate(0xc4200c2620, 0xc4200ec060, 0x2d)
        /home/vagrant/go/src/github.com/coreos/go-systemd/dbus/subscription.go:195 +0x40c
github.com/coreos/go-systemd/dbus.(*Conn).dispatch.func1(0xc420064120, 0xc4200c2620)
        /home/vagrant/go/src/github.com/coreos/go-systemd/dbus/subscription.go:94 +0x10c
created by github.com/coreos/go-systemd/dbus.(*Conn).dispatch
        /home/vagrant/go/src/github.com/coreos/go-systemd/dbus/subscription.go:62 +0x83
exit status 2
```

Printing `err` from https://github.com/coreos/go-systemd/blob/master/dbus/subscription.go#L186 shows:
```
Unit name /org/freedesktop/systemd1/unit/cron_2eservice is not valid.
```

And printing `path` from https://github.com/coreos/go-systemd/blob/master/dbus/methods.go#L156 shows that we're winding up with the `/org/freedesktop/systemd1/unit/` part of the path repeated (the second time escaped):
```
/org/freedesktop/systemd1/unit/_2forg_2ffreedesktop_2fsystemd1_2funit_2fcron_5f2eservice
```

If I missed something and this isn't an issue, or if you'd like to fix it differently, I'm happy to close the PR and resubmit as an issue instead.