### PR TITLE
login1: add close function

### DIFF
--- a/login1/dbus.go
+++ b/login1/dbus.go
@@ -45,6 +45,17 @@ func New() (*Conn, error) {
 	return c, nil
 }
 
+// Close closes the dbus connection
+func (c *Conn) Close() {
+	if c == nil {
+		return
+	}
+
+	if c.conn != nil {
+		c.conn.Close()
+	}
+}
+
 func (c *Conn) initConnection() error {
 	var err error
 	c.conn, err = dbus.SystemBusPrivate()


### PR DESCRIPTION
the close function closes the internal dbus connection, which is otherwise inaccessible. This allows for cleaner shutdown for clients of this library.