### PR TITLE
dbus: add SetPropertiesSubscriber method

### DIFF
--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -16,6 +16,7 @@
 package dbus
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strconv"
@@ -53,6 +54,27 @@ func PathBusEscape(path string) string {
 		if needsEscape(i, c) {
 			e := fmt.Sprintf("_%x", c)
 			n = append(n, []byte(e)...)
+		} else {
+			n = append(n, c)
+		}
+	}
+	return string(n)
+}
+
+// pathBusUnescape is the inverse of PathBusEscape.
+func pathBusUnescape(path string) string {
+	if path == "_" {
+		return ""
+	}
+	n := []byte{}
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if c == '_' && i+2 < len(path) {
+			res, err := hex.DecodeString(path[i+1 : i+3])
+			if err == nil {
+				n = append(n, res...)
+			}
+			i += 2
 		} else {
 			n = append(n, c)
 		}

--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -96,12 +96,17 @@ type Conn struct {
 		jobs map[dbus.ObjectPath]chan<- string
 		sync.Mutex
 	}
-	subscriber struct {
+	subStateSubscriber struct {
 		updateCh chan<- *SubStateUpdate
 		errCh    chan<- error
 		sync.Mutex
 		ignore      map[dbus.ObjectPath]int64
 		cleanIgnore int64
+	}
+	propertiesSubscriber struct {
+		updateCh chan<- *PropertiesUpdate
+		errCh    chan<- error
+		sync.Mutex
 	}
 }
 
@@ -174,7 +179,7 @@ func NewConnection(dialBus func() (*dbus.Conn, error)) (*Conn, error) {
 		sigobj:  systemdObject(sigconn),
 	}
 
-	c.subscriber.ignore = make(map[dbus.ObjectPath]int64)
+	c.subStateSubscriber.ignore = make(map[dbus.ObjectPath]int64)
 	c.jobListener.jobs = make(map[dbus.ObjectPath]chan<- string)
 
 	// Setup the listeners on jobs so that we can get completions

--- a/dbus/dbus_test.go
+++ b/dbus/dbus_test.go
@@ -67,6 +67,25 @@ func TestPathBusEscape(t *testing.T) {
 
 }
 
+func TestPathBusUnescape(t *testing.T) {
+	for in, want := range map[string]string{
+		"_":                      "",
+		"foo_2eservice":          "foo.service",
+		"foobar":                 "foobar",
+		"woof_40woof_2eservice":  "woof@woof.service",
+		"_30123456":              "0123456",
+		"account_5fdb_2eservice": "account_db.service",
+		"got_2ddashes":           "got-dashes",
+		"foobar_":                "foobar_",
+		"foobar_2":               "foobar_2",
+	} {
+		got := pathBusUnescape(in)
+		if got != want {
+			t.Errorf("bad result for pathBusUnescape(%s): got %q, want %q", in, got, want)
+		}
+	}
+}
+
 // TestNew ensures that New() works without errors.
 func TestNew(t *testing.T) {
 	_, err := New()

--- a/dbus/methods.go
+++ b/dbus/methods.go
@@ -584,3 +584,8 @@ func (c *Conn) Reload() error {
 func unitPath(name string) dbus.ObjectPath {
 	return dbus.ObjectPath("/org/freedesktop/systemd1/unit/" + PathBusEscape(name))
 }
+
+// unitName returns the unescaped base element of the supplied escaped path
+func unitName(dpath dbus.ObjectPath) string {
+	return pathBusUnescape(path.Base(string(dpath)))
+}

--- a/dbus/methods_test.go
+++ b/dbus/methods_test.go
@@ -1524,3 +1524,20 @@ func TestReload(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestUnitName(t *testing.T) {
+	for _, unit := range []string{
+		"",
+		"foo.service",
+		"foobar",
+		"woof@woof.service",
+		"0123456",
+		"account_db.service",
+		"got-dashes",
+	} {
+		got := unitName(unitPath(unit))
+		if got != unit {
+			t.Errorf("bad result for unitName(%s): got %q, want %q", unit, got, unit)
+		}
+	}
+}

--- a/dbus/subscription_test.go
+++ b/dbus/subscription_test.go
@@ -151,3 +151,59 @@ func TestSubStateSubscription(t *testing.T) {
 		}
 	}
 }
+
+// TestPropertiesSubscription exercises the basics of property change event subscriptions
+func TestPropertiesSubscription(t *testing.T) {
+	target := "subscribe-events.service"
+
+	conn, err := New()
+	defer conn.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = conn.Subscribe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updateCh := make(chan *PropertiesUpdate)
+	errCh := make(chan error)
+	conn.SetPropertiesSubscriber(updateCh, errCh)
+
+	setupUnit(target, conn, t)
+	linkUnit(target, conn, t)
+
+	reschan := make(chan string)
+	_, err = conn.StartUnit(target, "replace", reschan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	job := <-reschan
+	if job != "done" {
+		t.Fatal("Couldn't start", target)
+	}
+
+	timeout := make(chan bool, 1)
+	go func() {
+		time.Sleep(3 * time.Second)
+		close(timeout)
+	}()
+
+	for {
+		select {
+		case update := <-updateCh:
+			if update.UnitName == target {
+				subState, ok := update.Changed["SubState"].Value().(string)
+				if ok && subState == "running" {
+					return // success
+				}
+			}
+		case err := <-errCh:
+			t.Fatal(err)
+		case <-timeout:
+			t.Fatal("Reached timeout")
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a `SetPropertiesSubscriber` method which is similar to
`SetSubStateSubscriber` but with two important differences:

* Each update includes all changed properties, not just SubState
* Each set of property values from systemd is reported; no update can be
  missed. With `SubStateSubscriber`, transient states can be missed
  because `sendSubStateUpdate` calls `GetUnitPathProperties` after receiving
  the original signal from systemd; by this point, the unit's state may
  have changed again. (This behavior is clearly documented, but for some
  use cases it might not be acceptable to miss a state transition.)