### PR TITLE
activation: close files after creating listeners

### DIFF
--- a/activation/listeners.go
+++ b/activation/listeners.go
@@ -32,6 +32,9 @@ func Listeners(unsetEnv bool) ([]net.Listener, error) {
 	for i, f := range files {
 		if pc, err := net.FileListener(f); err == nil {
 			listeners[i] = pc
+			if unsetEnv {
+				f.Close()
+			}
 		}
 	}
 	return listeners, nil

--- a/activation/packetconns.go
+++ b/activation/packetconns.go
@@ -31,6 +31,9 @@ func PacketConns(unsetEnv bool) ([]net.PacketConn, error) {
 	for i, f := range files {
 		if pc, err := net.FilePacketConn(f); err == nil {
 			conns[i] = pc
+			if unsetEnv {
+				f.Close()
+			}
 		}
 	}
 	return conns, nil


### PR DESCRIPTION
This is an adaptation of #215 to ensure tests don't fail and extend
the behaviour to PacketConns(). A bit of test coverage is lost, but
just testing if variable environments are not unset in the simple case
doesn't seem worth adding more code.

Fix #215