### PR TITLE
activation: add two functions to provide listeners with names

### DIFF
--- a/activation/files.go
+++ b/activation/files.go
@@ -18,6 +18,7 @@ package activation
 import (
 	"os"
 	"strconv"
+	"strings"
 	"syscall"
 )
 
@@ -30,6 +31,7 @@ func Files(unsetEnv bool) []*os.File {
 	if unsetEnv {
 		defer os.Unsetenv("LISTEN_PID")
 		defer os.Unsetenv("LISTEN_FDS")
+		defer os.Unsetenv("LISTEN_FDNAMES")
 	}
 
 	pid, err := strconv.Atoi(os.Getenv("LISTEN_PID"))
@@ -42,10 +44,17 @@ func Files(unsetEnv bool) []*os.File {
 		return nil
 	}
 
+	names := strings.Split(os.Getenv("LISTEN_FDNAMES"), ":")
+
 	files := make([]*os.File, 0, nfds)
 	for fd := listenFdsStart; fd < listenFdsStart+nfds; fd++ {
 		syscall.CloseOnExec(fd)
-		files = append(files, os.NewFile(uintptr(fd), "LISTEN_FD_"+strconv.Itoa(fd)))
+		name := "LISTEN_FD_" + strconv.Itoa(fd)
+		offset := fd - listenFdsStart
+		if offset < len(names) && len(names[offset]) > 0 {
+			name = names[offset]
+		}
+		files = append(files, os.NewFile(uintptr(fd), name))
 	}
 
 	return files

--- a/activation/files_test.go
+++ b/activation/files_test.go
@@ -48,15 +48,15 @@ func TestActivation(t *testing.T) {
 	}
 
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "LISTEN_FDS=2", "FIX_LISTEN_PID=1")
+	cmd.Env = append(cmd.Env, "LISTEN_FDS=2", "LISTEN_FDNAMES=fd1", "FIX_LISTEN_PID=1")
 
 	err := cmd.Run()
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
 
-	correctStringWritten(t, r1, "Hello world")
-	correctStringWritten(t, r2, "Goodbye world")
+	correctStringWritten(t, r1, "Hello world: fd1")
+	correctStringWritten(t, r2, "Goodbye world: LISTEN_FD_4")
 }
 
 func TestActivationNoFix(t *testing.T) {

--- a/activation/listeners.go
+++ b/activation/listeners.go
@@ -37,6 +37,27 @@ func Listeners(unsetEnv bool) ([]net.Listener, error) {
 	return listeners, nil
 }
 
+// ListenersWithNames maps a listener name to a set of net.Listener instances.
+func ListenersWithNames(unsetEnv bool) (map[string][]net.Listener, error) {
+	files := Files(unsetEnv)
+	listeners := map[string][]net.Listener{}
+
+	for _, f := range files {
+		if pc, err := net.FileListener(f); err == nil {
+			current, ok := listeners[f.Name()]
+			if !ok {
+				listeners[f.Name()] = []net.Listener{pc}
+			} else {
+				listeners[f.Name()] = append(current, pc)
+			}
+			if unsetEnv {
+				f.Close()
+			}
+		}
+	}
+	return listeners, nil
+}
+
 // TLSListeners returns a slice containing a net.listener for each matching TCP socket type
 // passed to this process.
 // It uses default Listeners func and forces TCP sockets handlers to use TLS based on tlsConfig.
@@ -52,6 +73,29 @@ func TLSListeners(unsetEnv bool, tlsConfig *tls.Config) ([]net.Listener, error) 
 			// Activate TLS only for TCP sockets
 			if l.Addr().Network() == "tcp" {
 				listeners[i] = tls.NewListener(l, tlsConfig)
+			}
+		}
+	}
+
+	return listeners, err
+}
+
+// TLSListenersWithNames maps a listener name to a net.Listener with
+// the associated TLS configuration.
+func TLSListenersWithNames(unsetEnv bool, tlsConfig *tls.Config) (map[string][]net.Listener, error) {
+	listeners, err := ListenersWithNames(unsetEnv)
+
+	if listeners == nil || err != nil {
+		return nil, err
+	}
+
+	if tlsConfig != nil && err == nil {
+		for _, ll := range listeners {
+			// Activate TLS only for TCP sockets
+			for i, l := range ll {
+				if l.Addr().Network() == "tcp" {
+					ll[i] = tls.NewListener(l, tlsConfig)
+				}
 			}
 		}
 	}

--- a/activation/listeners_test.go
+++ b/activation/listeners_test.go
@@ -73,14 +73,14 @@ func TestListeners(t *testing.T) {
 	r2.Write([]byte("Hi"))
 
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "LISTEN_FDS=2", "FIX_LISTEN_PID=1")
+	cmd.Env = append(cmd.Env, "LISTEN_FDS=2", "LISTEN_FDNAMES=fd1:fd2", "FIX_LISTEN_PID=1")
 
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		println(string(out))
 		t.Fatalf(err.Error())
 	}
 
-	correctStringWrittenNet(t, r1, "Hello world")
-	correctStringWrittenNet(t, r2, "Goodbye world")
+	correctStringWrittenNet(t, r1, "Hello world: fd1")
+	correctStringWrittenNet(t, r2, "Goodbye world: fd2")
 }

--- a/activation/packetconns_test.go
+++ b/activation/packetconns_test.go
@@ -56,7 +56,7 @@ func TestPacketConns(t *testing.T) {
 	r2.Write([]byte("Hi"))
 
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "LISTEN_FDS=2", "FIX_LISTEN_PID=1")
+	cmd.Env = append(cmd.Env, "LISTEN_FDS=2", "LISTEN_FDNAMES=fd1:fd2", "FIX_LISTEN_PID=1")
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/examples/activation/activation.go
+++ b/examples/activation/activation.go
@@ -42,19 +42,19 @@ func main() {
 		panic("No files")
 	}
 
-	if os.Getenv("LISTEN_PID") == "" || os.Getenv("LISTEN_FDS") == "" {
+	if os.Getenv("LISTEN_PID") == "" || os.Getenv("LISTEN_FDS") == "" || os.Getenv("LISTEN_FDNAMES") == "" {
 		panic("Should not unset envs")
 	}
 
 	files = activation.Files(true)
 
-	if os.Getenv("LISTEN_PID") != "" || os.Getenv("LISTEN_FDS") != "" {
+	if os.Getenv("LISTEN_PID") != "" || os.Getenv("LISTEN_FDS") != "" || os.Getenv("LISTEN_FDNAMES") != "" {
 		panic("Can not unset envs")
 	}
 
 	// Write out the expected strings to the two pipes
-	files[0].Write([]byte("Hello world"))
-	files[1].Write([]byte("Goodbye world"))
+	files[0].Write([]byte("Hello world: " + files[0].Name()))
+	files[1].Write([]byte("Goodbye world: " + files[1].Name()))
 
 	return
 }

--- a/examples/activation/listen.go
+++ b/examples/activation/listen.go
@@ -42,25 +42,25 @@ func main() {
 		panic("No listeners")
 	}
 
-	if os.Getenv("LISTEN_PID") == "" || os.Getenv("LISTEN_FDS") == "" {
+	if os.Getenv("LISTEN_PID") == "" || os.Getenv("LISTEN_FDS") == "" || os.Getenv("LISTEN_FDNAMES") == "" {
 		panic("Should not unset envs")
 	}
 
-	listeners, err := activation.Listeners(true)
+	listenersWithNames, err := activation.ListenersWithNames(true)
 	if err != nil {
 		panic(err)
 	}
 
-	if os.Getenv("LISTEN_PID") != "" || os.Getenv("LISTEN_FDS") != "" {
+	if os.Getenv("LISTEN_PID") != "" || os.Getenv("LISTEN_FDS") != "" || os.Getenv("LISTEN_FDNAMES") != "" {
 		panic("Can not unset envs")
 	}
 
-	c0, _ := listeners[0].Accept()
-	c1, _ := listeners[1].Accept()
+	c0, _ := listenersWithNames["fd1"][0].Accept()
+	c1, _ := listenersWithNames["fd2"][0].Accept()
 
 	// Write out the expected strings to the two pipes
-	c0.Write([]byte("Hello world"))
-	c1.Write([]byte("Goodbye world"))
+	c0.Write([]byte("Hello world: fd1"))
+	c1.Write([]byte("Goodbye world: fd2"))
 
 	return
 }

--- a/examples/activation/udpconn.go
+++ b/examples/activation/udpconn.go
@@ -43,7 +43,7 @@ func main() {
 		panic("No packetConns")
 	}
 
-	if os.Getenv("LISTEN_PID") == "" || os.Getenv("LISTEN_FDS") == "" {
+	if os.Getenv("LISTEN_PID") == "" || os.Getenv("LISTEN_FDS") == "" || os.Getenv("LISTEN_FDNAMES") == "" {
 		panic("Should not unset envs")
 	}
 
@@ -52,7 +52,7 @@ func main() {
 		panic(err)
 	}
 
-	if os.Getenv("LISTEN_PID") != "" || os.Getenv("LISTEN_FDS") != "" {
+	if os.Getenv("LISTEN_PID") != "" || os.Getenv("LISTEN_FDS") != "" || os.Getenv("LISTEN_FDNAMES") != "" {
 		panic("Can not unset envs")
 	}
 


### PR DESCRIPTION
Since v227, systemd can name each listener. This is useful when you
have different socket units activating the same service: you can't
really know in which order the socket will be provided. Systemd adds
an environment variable named LISTEN_FDNAMES for this purpose.

We encapsulate the name in the File object created from the file
descriptor. Unfortunately, once this is turned into a net.Listener,
there doesn't seem to have a way to fetch this information
back. Therefore, two new functions are provided to be able to easily
get named sockets.

The same could be done to PacketConns in the future.