### PR TITLE
sdjournal: propagate AddMatch errors in constructor

### DIFF
--- a/sdjournal/read.go
+++ b/sdjournal/read.go
@@ -84,7 +84,9 @@ func NewJournalReader(config JournalReaderConfig) (*JournalReader, error) {
 
 	// Add any supplied matches
 	for _, m := range config.Matches {
-		r.journal.AddMatch(m.String())
+		if err = r.journal.AddMatch(m.String()); err != nil {
+			return nil, err
+		}
 	}
 
 	// Set the start position based on options


### PR DESCRIPTION
When creating a new JournalReader any errors returned by `r.journal.AddMatch(string)` got ignored. I think we should return any errors.