### PR TITLE
sdjournal: add docstrings for public error values

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -372,8 +372,8 @@ const (
 )
 
 var (
-	// Error show when using TestCursor function and cursor parameter is not the same
-	// as the current cursor position
+	// ErrNoTestCursor gets returned when using TestCursor function and cursor
+	// parameter is not the same as the current cursor position.
 	ErrNoTestCursor = errors.New("Cursor parameter is not the same as current position")
 )
 

--- a/sdjournal/read.go
+++ b/sdjournal/read.go
@@ -25,6 +25,8 @@ import (
 )
 
 var (
+	// ErrExpired gets returned when the Follow function runs into the
+	// specified timeout.
 	ErrExpired = errors.New("Timeout expired")
 )
 


### PR DESCRIPTION
Fixed typo in `ErrNoTestCursor`'s comment and added one for `ErrExpired`.