### PR TITLE
Linter warnings fixed for unit sources

### DIFF
--- a/unit/deserialize.go
+++ b/unit/deserialize.go
@@ -33,11 +33,13 @@ const (
 	// but this would introduce an (unfortunate) dependency on cgo
 	SYSTEMD_LINE_MAX = 2048
 
-	// characters that systemd considers indicate a newline
+	// SYSTEMD_NEWLINE defines characters that systemd considers indicators
+	// for a newline.
 	SYSTEMD_NEWLINE = "\r\n"
 )
 
 var (
+	// ErrLineTooLong gets returned when a line is too long for systemd to handle.
 	ErrLineTooLong = fmt.Errorf("line too long (max %d bytes)", SYSTEMD_LINE_MAX)
 )
 

--- a/unit/deserialize_test.go
+++ b/unit/deserialize_test.go
@@ -267,7 +267,7 @@ Option=value
 			return fmt.Errorf("expected %d items, got %d", len(expect), len(output))
 		}
 
-		for i, _ := range expect {
+		for i := range expect {
 			if !reflect.DeepEqual(expect[i], output[i]) {
 				return fmt.Errorf("item %d: expected %v, got %v", i, expect[i], output[i])
 			}

--- a/unit/option.go
+++ b/unit/option.go
@@ -18,12 +18,14 @@ import (
 	"fmt"
 )
 
+// UnitOption represents an option in a systemd unit file.
 type UnitOption struct {
 	Section string
 	Name    string
 	Value   string
 }
 
+// NewUnitOption returns a new UnitOption instance with pre-set values.
 func NewUnitOption(section, name, value string) *UnitOption {
 	return &UnitOption{Section: section, Name: name, Value: value}
 }
@@ -32,12 +34,15 @@ func (uo *UnitOption) String() string {
 	return fmt.Sprintf("{Section: %q, Name: %q, Value: %q}", uo.Section, uo.Name, uo.Value)
 }
 
+// Match compares two UnitOptions and returns true if they are identical.
 func (uo *UnitOption) Match(other *UnitOption) bool {
 	return uo.Section == other.Section &&
 		uo.Name == other.Name &&
 		uo.Value == other.Value
 }
 
+// AllMatch compares two slices of UnitOptions and returns true if they are
+// identical.
 func AllMatch(u1 []*UnitOption, u2 []*UnitOption) bool {
 	length := len(u1)
 	if length != len(u2) {


### PR DESCRIPTION
- Added missing godoc-style code comments
- Omitted redundant second value from range