### PR TITLE
unit: avoid unneeded variable shadowing

### DIFF
--- a/unit/deserialize.go
+++ b/unit/deserialize.go
@@ -70,7 +70,6 @@ type lexer struct {
 }
 
 func (l *lexer) lex() {
-	var err error
 	defer func() {
 		close(l.optchan)
 		close(l.errchan)
@@ -93,6 +92,7 @@ func (l *lexer) lex() {
 			}
 		}
 
+		var err error
 		next, err = next()
 		if err != nil {
 			l.errchan <- err


### PR DESCRIPTION
It's enough to declare err a bit later.