### PR TITLE
unit: use ContainsAny instead of IndexAny

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
   global:
     - IMPORTPATH=github.com/coreos/go-systemd
     - GOPATH=/opt
-    - GO15VENDOREXPERIMENT=1
     - DEP_BINDIR=/tmp
     - BUILD_DIR=/opt/src/github.com/coreos/go-systemd
   matrix:

--- a/unit/deserialize.go
+++ b/unit/deserialize.go
@@ -88,7 +88,7 @@ func (l *lexer) lex() {
 				l.errchan <- err
 				return
 			}
-			if bytes.IndexAny(line, SYSTEMD_NEWLINE) == -1 {
+			if !bytes.ContainsAny(line, SYSTEMD_NEWLINE) {
 				l.errchan <- ErrLineTooLong
 				return
 			}


### PR DESCRIPTION
Caution: If I'm not mistaken `ContainsAny` wasn't available before Go 1.5. I'm not sure which minimum Go version go-systemd is aiming for, but if it's still <1.5 then you might not want to merge this PR.

That being said, I think it reads nicer.

Edit: I was mistaken, `bytes.ContainsAny` was introduced with the 1.7 release.