### PR TITLE
daemon: add convenience constants for SdNotify

### DIFF
--- a/daemon/sdnotify.go
+++ b/daemon/sdnotify.go
@@ -21,6 +21,25 @@ import (
 	"os"
 )
 
+const (
+	// SdNotifyReady tells the service manager that service startup is finished
+	// or the service finished loading its configuration.
+	SdNotifyReady = "READY=1"
+
+	// SdNotifyStopping tells the service manager that the service is beginning
+	// its shutdown.
+	SdNotifyStopping = "STOPPING=1"
+
+	// SdNotifyReloading tells the service manager that this service is
+	// reloading its configuration. Note that you must call SdNotifyReady when
+	// it completed reloading.
+	SdNotifyReloading = "RELOADING=1"
+
+	// SdNotifyWatchdog tells the service manager to update the watchdog
+	// timestamp for the service.
+	SdNotifyWatchdog = "WATCHDOG=1"
+)
+
 // SdNotify sends a message to the init daemon. It is common to ignore the error.
 // If `unsetEnvironment` is true, the environment variable `NOTIFY_SOCKET`
 // will be unconditionally unset.

--- a/daemon/watchdog.go
+++ b/daemon/watchdog.go
@@ -21,10 +21,11 @@ import (
 	"time"
 )
 
-// SdWatchdogEnabled return watchdog information for a service.
-// Process should send daemon.SdNotify("WATCHDOG=1") every time / 2.
-// If `unsetEnvironment` is true, the environment variables `WATCHDOG_USEC`
-// and `WATCHDOG_PID` will be unconditionally unset.
+// SdWatchdogEnabled returns watchdog information for a service.
+// Processes should call daemon.SdNotify(false, daemon.SdNotifyWatchdog) every
+// time / 2.
+// If `unsetEnvironment` is true, the environment variables `WATCHDOG_USEC` and
+// `WATCHDOG_PID` will be unconditionally unset.
 //
 // It returns one of the following:
 // (0, nil) - watchdog isn't enabled or we aren't the watched PID.


### PR DESCRIPTION
This provides convenient little helper methods for the common service notifications, while hiding the "protocol" details from the API caller.

- SdNotifyReady to signal readiness
- SdNotifyStopping to signal beginning of shutdown
- SdNotifyReloading to signal configuration reloading
- SdNotifyWatchdog to update the watchdog timestamp