### PR TITLE
activation: Fix compilation issue during go get activation on files.go

### DIFF
--- a/activation/files.go
+++ b/activation/files.go
@@ -48,7 +48,7 @@ func Files(unsetEnv bool) []*os.File {
 
 	files := make([]*os.File, 0, nfds)
 	for fd := listenFdsStart; fd < listenFdsStart+nfds; fd++ {
-		syscall.CloseOnExec(fd)
+		syscall.CloseOnExec(syscall.Handle(fd))
 		name := "LISTEN_FD_" + strconv.Itoa(fd)
 		offset := fd - listenFdsStart
 		if offset < len(names) && len(names[offset]) > 0 {


### PR DESCRIPTION
github.com/coreos/go-systemd/activation/files.go:51:22:
cannot use fd (type int) as type syscall.Handle in argument to syscall.CloseOnExec