### PR TITLE
travis: split test compilation and run phases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,33 @@
-language: shell # We do everything inside Docker and don't want travis fiddling with steps or environment variables
-
+dist: trusty
 sudo: required
-
 services:
   - docker
 
+language: go
+go:
+  - "1.5.x"
+  - "1.10.x"
+go_import_path: github.com/coreos/go-systemd
+
 env:
   global:
+    - IMPORTPATH=github.com/coreos/go-systemd
     - GOPATH=/opt
+    - GO15VENDOREXPERIMENT=1
+    - DEP_BINDIR=/tmp
     - BUILD_DIR=/opt/src/github.com/coreos/go-systemd
   matrix:
+    - DOCKER_BASE=ubuntu:16.04
     - DOCKER_BASE=ubuntu:18.04
     - DOCKER_BASE=debian:stretch
 
 before_install:
+ - sudo apt-get -qq update
+ - sudo apt-get install -y libsystemd-journal-dev libsystemd-daemon-dev
+ - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | INSTALL_DIRECTORY=${DEP_BINDIR} sh
+ - ${DEP_BINDIR}/dep ensure -v
  - docker pull ${DOCKER_BASE}
- - docker run --privileged -e GOPATH=${GOPATH} --cidfile=/tmp/cidfile ${DOCKER_BASE} /bin/bash -c "apt-get update && apt-get install -y build-essential git golang dbus libsystemd-dev libpam-systemd systemd-container && go get github.com/coreos/pkg/dlopen && go get github.com/godbus/dbus"
+ - docker run --privileged -e GOPATH=${GOPATH} --cidfile=/tmp/cidfile ${DOCKER_BASE} /bin/bash -c "apt-get update && apt-get install -y sudo build-essential git golang dbus libsystemd-dev libpam-systemd systemd-container"
  - docker commit `cat /tmp/cidfile` go-systemd/container-tests
  - rm -f /tmp/cidfile
 
@@ -23,7 +35,12 @@ install:
  - docker run -d --cidfile=/tmp/cidfile --privileged -e GOPATH=${GOPATH} -v ${PWD}:${BUILD_DIR} go-systemd/container-tests /bin/systemd --system
 
 script:
- - docker exec `cat /tmp/cidfile` /bin/bash -c "cd ${BUILD_DIR} && ./test"
+ - ./scripts/travis/pr-test.sh go_fmt
+ - ./scripts/travis/pr-test.sh build_source
+ - ./scripts/travis/pr-test.sh build_tests
+ - docker exec `cat /tmp/cidfile` /bin/bash -c "cd ${BUILD_DIR} && ./scripts/travis/pr-test.sh run_tests"
+ - ./scripts/travis/pr-test.sh go_vet
+ - ./scripts/travis/pr-test.sh license_check
 
 after_script:
  - docker kill `cat /tmp/cidfile`

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,0 +1,11 @@
+[[constraint]]
+  name = "github.com/coreos/pkg"
+  version = "4.0.0"
+
+[[constraint]]
+  name = "github.com/godbus/dbus"
+  version = "4.1.0"
+
+[prune]
+  go-tests = true
+  unused-packages = true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/coreos/go-systemd.png?branch=master)](https://travis-ci.org/coreos/go-systemd)
 [![godoc](https://godoc.org/github.com/coreos/go-systemd?status.svg)](http://godoc.org/github.com/coreos/go-systemd)
+![minimum golang 1.5](https://img.shields.io/badge/golang-1.5%2B-orange.svg)
+
 
 Go bindings to systemd. The project has several packages:
 

--- a/activation/common_test.go
+++ b/activation/common_test.go
@@ -1,0 +1,31 @@
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package activation
+
+import (
+	"fmt"
+	"os"
+)
+
+// exampleCmd returns the command line for the specified example binary.
+func exampleCmd(binaryName string) (string, []string) {
+	sourcePath := fmt.Sprintf("../examples/activation/%s.go", binaryName)
+	sourceCmdLine := []string{"go", "run", sourcePath}
+	binaryPath := fmt.Sprintf("../test_bins/%s.example", binaryName)
+	if _, err := os.Stat(binaryPath); err != nil && os.IsNotExist(err) {
+		return sourceCmdLine[0], sourceCmdLine
+	}
+	return binaryPath, []string{binaryPath}
+}

--- a/activation/files_test.go
+++ b/activation/files_test.go
@@ -38,7 +38,8 @@ func correctStringWritten(t *testing.T, r *os.File, expected string) bool {
 // TestActivation forks out a copy of activation.go example and reads back two
 // strings from the pipes that are passed in.
 func TestActivation(t *testing.T) {
-	cmd := exec.Command("go", "run", "../examples/activation/activation.go")
+	arg0, cmdline := exampleCmd("activation")
+	cmd := exec.Command(arg0, cmdline...)
 
 	r1, w1, _ := os.Pipe()
 	r2, w2, _ := os.Pipe()
@@ -60,7 +61,8 @@ func TestActivation(t *testing.T) {
 }
 
 func TestActivationNoFix(t *testing.T) {
-	cmd := exec.Command("go", "run", "../examples/activation/activation.go")
+	arg0, cmdline := exampleCmd("activation")
+	cmd := exec.Command(arg0, cmdline...)
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "LISTEN_FDS=2")
 
@@ -71,7 +73,8 @@ func TestActivationNoFix(t *testing.T) {
 }
 
 func TestActivationNoFiles(t *testing.T) {
-	cmd := exec.Command("go", "run", "../examples/activation/activation.go")
+	arg0, cmdline := exampleCmd("activation")
+	cmd := exec.Command(arg0, cmdline...)
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "LISTEN_FDS=0", "FIX_LISTEN_PID=1")
 

--- a/activation/listeners_test.go
+++ b/activation/listeners_test.go
@@ -38,7 +38,8 @@ func correctStringWrittenNet(t *testing.T, r net.Conn, expected string) bool {
 // TestActivation forks out a copy of activation.go example and reads back two
 // strings from the pipes that are passed in.
 func TestListeners(t *testing.T) {
-	cmd := exec.Command("go", "run", "../examples/activation/listen.go")
+	arg0, cmdline := exampleCmd("listen")
+	cmd := exec.Command(arg0, cmdline...)
 
 	l1, err := net.Listen("tcp", ":9999")
 	if err != nil {

--- a/activation/packetconns_test.go
+++ b/activation/packetconns_test.go
@@ -24,7 +24,8 @@ import (
 // TestActivation forks out a copy of activation.go example and reads back two
 // strings from the pipes that are passed in.
 func TestPacketConns(t *testing.T) {
-	cmd := exec.Command("go", "run", "../examples/activation/udpconn.go")
+	arg0, cmdline := exampleCmd("udpconn")
+	cmd := exec.Command(arg0, cmdline...)
 
 	u1, err := net.ListenUDP("udp", &net.UDPAddr{Port: 9999})
 	if err != nil {

--- a/journal/journal_test.go
+++ b/journal/journal_test.go
@@ -1,0 +1,42 @@
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package journal
+
+import (
+	"testing"
+)
+
+func TestValidaVarName(t *testing.T) {
+	testCases := []struct {
+		testcase string
+		valid    bool
+	}{
+		{
+			"TEST",
+			true,
+		},
+		{
+			"test",
+			false,
+		},
+	}
+
+	for _, tt := range testCases {
+		valid := validVarName(tt.testcase)
+		if valid != tt.valid {
+			t.Fatalf("expected %t, got %t", tt.valid, valid)
+		}
+	}
+}

--- a/scripts/travis/pr-test.sh
+++ b/scripts/travis/pr-test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+PROJ="go-systemd"
+ORG_PATH="github.com/coreos"
+REPO_PATH="${ORG_PATH}/${PROJ}"
+
+PACKAGES="activation daemon dbus journal login1 machine1 sdjournal unit util"
+EXAMPLES="activation listen udpconn"
+
+function build_source {
+    go build ./...
+}
+
+function build_tests {
+    rm -rf ./test_bins ; mkdir -p ./test_bins
+    for pkg in ${PACKAGES}; do
+        echo "  - ${pkg}"
+        go test -c -o ./test_bins/${pkg}.test ./${pkg}
+    done
+    for ex in ${EXAMPLES}; do
+        echo "  - examples/${ex}"
+        go build -o ./test_bins/${ex}.example ./examples/activation/${ex}.go
+    done
+}
+
+function run_tests {
+    pushd test_bins
+    sudo -v
+    for pkg in ${PACKAGES}; do
+        echo "  - ${pkg}"
+        sudo -E ./${pkg}.test -test.v
+    done
+    popd
+    rm -rf ./test_bins
+}
+
+function go_fmt {
+    for pkg in ${PACKAGES}; do
+        echo "  - ${pkg}"
+        fmtRes=$(gofmt -l "./${pkg}")
+        if [ -n "${fmtRes}" ]; then
+            echo -e "gofmt checking failed:\n${fmtRes}"
+            exit 255
+        fi
+    done
+}
+
+function go_vet {
+    for pkg in ${PACKAGES}; do
+        echo "  - ${pkg}"
+        vetRes=$(go vet "./${pkg}")
+        if [ -n "${vetRes}" ]; then
+            echo -e "govet checking failed:\n${vetRes}"
+            exit 254
+        fi
+    done
+}
+
+function license_check {
+    licRes=$(for file in $(find . -type f -iname '*.go' ! -path './vendor/*'); do
+  	             head -n3 "${file}" | grep -Eq "(Copyright|generated|GENERATED)" || echo -e "  ${file}"
+  	         done;)
+    if [ -n "${licRes}" ]; then
+        echo -e "license header checking failed:\n${licRes}"
+  	    exit 253
+    fi
+}
+
+export GO15VENDOREXPERIMENT=1
+
+subcommand="$1"
+case "$subcommand" in
+    "build_source" )
+        echo "Building source..."
+        build_source
+        ;;
+
+    "build_tests" )
+        echo "Building tests..."
+        build_tests
+        ;;
+
+    "run_tests" )
+        echo "Running tests..."
+        run_tests
+        ;;
+
+    "go_fmt" )
+        echo "Checking gofmt..."
+        go_fmt
+        ;;
+
+    "go_vet" )
+        echo "Checking govet..."
+        go_vet
+        ;;
+
+    "license_check" )
+        echo "Checking licenses..."
+        license_check
+        ;;
+
+    * )
+        echo "Error: unrecognized subcommand."
+        exit 1
+    ;;
+esac

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -40,6 +40,11 @@ func TestRunningFromSystemService(t *testing.T) {
 func TestCurrentUnitName(t *testing.T) {
 	testIsRunningSystemd(t)
 
+	fromService, err := RunningFromSystemService()
+	if err != nil || !fromService {
+		t.Skip("Not running from a systemd service")
+	}
+
 	s, err := CurrentUnitName()
 	if err != nil {
 		t.Error(err.Error())


### PR DESCRIPTION
This rework how are tests are built and run on Travis, splitting it in multiple phases. Thus, it allows to compile with arbitrary golang toolchains (as offered on Travis) and test against arbitrary systemd versions (as shipped by distributions, via Docker).
It also adds a [dep](https://github.com/golang/dep) manifest to fetch dependencies, but no lockfile nor vendor directory.