### PR TITLE
machine1: add methods ListMachines, ListImages, GetMachineAddresses

### DIFF
--- a/machine1/dbus.go
+++ b/machine1/dbus.go
@@ -125,6 +125,11 @@ func (c *Conn) GetMachineByPID(pid uint) (dbus.ObjectPath, error) {
 	return c.getPath("GetMachineByPID", pid)
 }
 
+// GetMachineAddresses gets a list of IP addresses
+func (c *Conn) GetMachineAddresses(name string) (dbus.ObjectPath, error) {
+	return c.getPath("GetMachineAddresses", name)
+}
+
 // DescribeMachine gets the properties of a machine
 func (c *Conn) DescribeMachine(name string) (machineProps map[string]interface{}, err error) {
 	var dbusProps map[string]dbus.Variant

--- a/machine1/dbus.go
+++ b/machine1/dbus.go
@@ -45,6 +45,17 @@ type MachineStatus struct {
 	JobPath dbus.ObjectPath // The job object path
 }
 
+// ImageStatus is a set of necessary info for each machine image
+type ImageStatus struct {
+	Name       string          // The primary image name as string
+	ImageType  string          // The image type as string
+	Readonly   bool            // whether it's readonly or not
+	CreateTime uint64          // time when it's created
+	ModifyTime uint64          // time when it's modified
+	DiskUsage  uint64          // used disk space
+	JobPath    dbus.ObjectPath // The job object path
+}
+
 // New() establishes a connection to the system bus and authenticates.
 func New() (*Conn, error) {
 	c := new(Conn)
@@ -190,4 +201,60 @@ func (c *Conn) ListMachines() ([]MachineStatus, error) {
 	}
 
 	return machs, nil
+}
+
+func imageFromInterfaces(image []interface{}) (*ImageStatus, error) {
+	if len(image) < 7 {
+		return nil, fmt.Errorf("invalid number of image fields: %d", len(image))
+	}
+	name, ok := image[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to typecast image field 0 to string")
+	}
+	imagetype, ok := image[1].(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to typecast imagetype field 1 to string")
+	}
+	readonly, ok := image[2].(bool)
+	if !ok {
+		return nil, fmt.Errorf("failed to typecast readonly field 2 to bool")
+	}
+	createtime, ok := image[3].(uint64)
+	if !ok {
+		return nil, fmt.Errorf("failed to typecast createtime field 3 to uint64")
+	}
+	modifytime, ok := image[4].(uint64)
+	if !ok {
+		return nil, fmt.Errorf("failed to typecast modifytime field 4 to uint64")
+	}
+	diskusage, ok := image[5].(uint64)
+	if !ok {
+		return nil, fmt.Errorf("failed to typecast diskusage field 5 to uint64")
+	}
+	jobpath, ok := image[6].(dbus.ObjectPath)
+	if !ok {
+		return nil, fmt.Errorf("failed to typecast jobpath field 6 to ObjectPath")
+	}
+
+	ret := ImageStatus{Name: name, ImageType: imagetype, Readonly: readonly, CreateTime: createtime, ModifyTime: modifytime, DiskUsage: diskusage, JobPath: jobpath}
+	return &ret, nil
+}
+
+// ListImages returns an array of all currently available images.
+func (c *Conn) ListImages() ([]ImageStatus, error) {
+	result := make([][]interface{}, 0)
+	if err := c.object.Call(dbusInterface+".ListImages", 0).Store(&result); err != nil {
+		return nil, err
+	}
+
+	images := []ImageStatus{}
+	for _, i := range result {
+		image, err := imageFromInterfaces(i)
+		if err != nil {
+			return nil, err
+		}
+		images = append(images, *image)
+	}
+
+	return images, nil
 }

--- a/machine1/dbus_test.go
+++ b/machine1/dbus_test.go
@@ -19,7 +19,9 @@ package machine1
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -111,4 +113,32 @@ func generateRandomLabel(n int) string {
 		s[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(s)
+}
+
+func TestImages(t *testing.T) {
+	imageName := machinePrefix + generateRandomLabel(8)
+	imagePath := filepath.Join("/var/lib/machines", imageName)
+
+	if _, err := os.Create(imagePath); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(imagePath)
+
+	if err := os.Truncate(imagePath, 500*1024*1024); err != nil {
+		t.Fatal(err)
+	}
+
+	conn, newErr := New()
+	if newErr != nil {
+		t.Fatal(newErr)
+	}
+
+	listImages, listErr := conn.ListImages()
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+
+	if len(listImages) < 1 {
+		t.Fatalf("did not find any image")
+	}
 }

--- a/machine1/dbus_test.go
+++ b/machine1/dbus_test.go
@@ -80,6 +80,16 @@ func TestMachine(t *testing.T) {
 		t.Fatalf("did not find machine named %s", machineName)
 	}
 
+	listMachines, getErr := conn.ListMachines()
+	if getErr != nil {
+		t.Fatal(getErr)
+	}
+
+	// listMachines includes also `.host`, so by default the length should be greater than 1
+	if len(listMachines) <= 1 {
+		t.Fatalf("did not find any machine")
+	}
+
 	tErr := conn.TerminateMachine(machineName)
 	if tErr != nil {
 		t.Fatal(tErr)


### PR DESCRIPTION
Add new DBUS methods exposed already by systemd.

* `ListMachines`: lists all active machines
* `ListImages`: lists all images under `/var/lib/machines`.
* `GetMachineAddresses`, which gets a list of IP addresses of the given machine name.

See also https://github.com/kinvolk/kube-spawn/issues/241#issuecomment-425708704