### PR TITLE
dbus: Fix API break from godbus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ services:
 
 language: go
 go:
-  - "1.5.x"
+  - "1.7.x"
   - "1.10.x"
+  - "1.11.x"
 go_import_path: github.com/coreos/go-systemd
 
 env:

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/godbus/dbus"
-  version = "4.1.0"
+  version = "5.0"
 
 [prune]
   go-tests = true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/coreos/go-systemd.png?branch=master)](https://travis-ci.org/coreos/go-systemd)
 [![godoc](https://godoc.org/github.com/coreos/go-systemd?status.svg)](http://godoc.org/github.com/coreos/go-systemd)
-![minimum golang 1.5](https://img.shields.io/badge/golang-1.5%2B-orange.svg)
+![minimum golang 1.7](https://img.shields.io/badge/golang-1.7%2B-orange.svg)
 
 
 Go bindings to systemd. The project has several packages:

--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -143,7 +143,7 @@ func NewUserConnection() (*Conn, error) {
 func NewSystemdConnection() (*Conn, error) {
 	return NewConnection(func() (*dbus.Conn, error) {
 		// We skip Hello when talking directly to systemd.
-		return dbusAuthConnection(func() (*dbus.Conn, error) {
+		return dbusAuthConnection(func(opts ...dbus.ConnOption) (*dbus.Conn, error) {
 			return dbus.Dial("unix:path=/run/systemd/private")
 		})
 	})
@@ -201,7 +201,7 @@ func (c *Conn) GetManagerProperty(prop string) (string, error) {
 	return variant.String(), nil
 }
 
-func dbusAuthConnection(createBus func() (*dbus.Conn, error)) (*dbus.Conn, error) {
+func dbusAuthConnection(createBus func(opts ...dbus.ConnOption) (*dbus.Conn, error)) (*dbus.Conn, error) {
 	conn, err := createBus()
 	if err != nil {
 		return nil, err
@@ -221,7 +221,7 @@ func dbusAuthConnection(createBus func() (*dbus.Conn, error)) (*dbus.Conn, error
 	return conn, nil
 }
 
-func dbusAuthHelloConnection(createBus func() (*dbus.Conn, error)) (*dbus.Conn, error) {
+func dbusAuthHelloConnection(createBus func(opts ...dbus.ConnOption) (*dbus.Conn, error)) (*dbus.Conn, error) {
 	conn, err := dbusAuthConnection(createBus)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Something in godbus seems to have broken API, thus breaking builds
including `go get`. This patches fixes those changes. I don't know any
background about this change, so if anyone has information, I'd sure
like to know! Thanks