### PR TITLE
dbus: Add GetUnitByPID

### DIFF
--- a/dbus/methods.go
+++ b/dbus/methods.go
@@ -288,6 +288,15 @@ func (c *Conn) listUnitsInternal(f storeFunc) ([]UnitStatus, error) {
 	return status, nil
 }
 
+// GetUnitByPID returns an array with all currently loaded units. Note that
+func (c *Conn) GetUnitByPID(pid int) (dbus.ObjectPath, error) {
+	var op dbus.ObjectPath
+	if err := c.sysobj.Call("org.freedesktop.systemd1.Manager.GetUnitByPID", 0, uint(pid)).Store(&op); err != nil {
+		return dbus.ObjectPath(""), err
+	}
+	return op, nil
+}
+
 // ListUnits returns an array with all currently loaded units. Note that
 // units may be known by multiple names at the same time, and hence there might
 // be more unit names loaded than actual units behind them.

--- a/fixtures/get-unit-pid.service
+++ b/fixtures/get-unit-pid.service
@@ -1,0 +1,5 @@
+[Unit]
+Description=get unit pid
+
+[Service]
+ExecStart=get-unit-pid.sh

--- a/fixtures/get-unit-pid.sh
+++ b/fixtures/get-unit-pid.sh
@@ -1,0 +1,2 @@
+/bin/echo ${PID} >get-unit-pid.pid
+/bin/sleep 400


### PR DESCRIPTION
This implements the `org.freedesktop.systemd1.Manager.GetUnitByPID` method from https://www.freedesktop.org/wiki/Software/systemd/dbus/

The test is a very rough outline - I couldn't get it to run locally. Any tips on that?