### PR TITLE
journal: skip sending test if journald is unavailable

### DIFF
--- a/journal/journal_test.go
+++ b/journal/journal_test.go
@@ -49,6 +49,10 @@ func TestValidVarName(t *testing.T) {
 }
 
 func TestJournalSend(t *testing.T) {
+	if !Enabled() {
+		t.Skip("systemd journal not available locally")
+	}
+
 	// an always-too-big value (hopefully)
 	hugeValue := 1234567890
 


### PR DESCRIPTION
TestJournalSend tries to communicate with the local journald and send some messages there. There are environments where go-systemd is useful but there is no local journald available. In these cases it should still be possible to run the test suite successfully.