### PR TITLE
examples: systemd-activate is now systemd-socket-activate

### DIFF
--- a/examples/activation/httpserver/README.md
+++ b/examples/activation/httpserver/README.md
@@ -8,7 +8,7 @@ To try it out `go get` the httpserver and run it under the systemd-activate help
 ```bash
 export GOPATH="$PWD"
 go get github.com/coreos/go-systemd/examples/activation/httpserver
-/usr/lib/systemd/systemd-activate -l 127.0.0.1:8076 ./bin/httpserver
+systemd-socket-activate -l 127.0.0.1:8076 ./bin/httpserver
 ```
 
 Then curl the URL and you will notice that it starts up:


### PR DESCRIPTION
systemd-activate is now systemd-socket-activate