### PR TITLE
docs: fix multiple docstrings

### DIFF
--- a/dbus/methods.go
+++ b/dbus/methods.go
@@ -117,13 +117,13 @@ func (c *Conn) TryRestartUnit(name string, mode string, ch chan<- string) (int, 
 	return c.startJob(ch, "org.freedesktop.systemd1.Manager.TryRestartUnit", name, mode)
 }
 
-// ReloadOrRestart attempts a reload if the unit supports it and use a restart
+// ReloadOrRestartUnit attempts a reload if the unit supports it and use a restart
 // otherwise.
 func (c *Conn) ReloadOrRestartUnit(name string, mode string, ch chan<- string) (int, error) {
 	return c.startJob(ch, "org.freedesktop.systemd1.Manager.ReloadOrRestartUnit", name, mode)
 }
 
-// ReloadOrTryRestart attempts a reload if the unit supports it and use a "Try"
+// ReloadOrTryRestartUnit attempts a reload if the unit supports it and use a "Try"
 // flavored restart otherwise.
 func (c *Conn) ReloadOrTryRestartUnit(name string, mode string, ch chan<- string) (int, error) {
 	return c.startJob(ch, "org.freedesktop.systemd1.Manager.ReloadOrTryRestartUnit", name, mode)
@@ -192,7 +192,7 @@ func (c *Conn) GetUnitProperties(unit string) (map[string]interface{}, error) {
 	return c.getProperties(path, "org.freedesktop.systemd1.Unit")
 }
 
-// GetUnitProperties takes the (escaped) unit path and returns all of its dbus object properties.
+// GetUnitPathProperties takes the (escaped) unit path and returns all of its dbus object properties.
 func (c *Conn) GetUnitPathProperties(path dbus.ObjectPath) (map[string]interface{}, error) {
 	return c.getProperties(path, "org.freedesktop.systemd1.Unit")
 }

--- a/dbus/subscription.go
+++ b/dbus/subscription.go
@@ -94,7 +94,7 @@ func (c *Conn) dispatch() {
 	}()
 }
 
-// Returns two unbuffered channels which will receive all changed units every
+// SubscribeUnits returns two unbuffered channels which will receive all changed units every
 // interval.  Deleted units are sent as nil.
 func (c *Conn) SubscribeUnits(interval time.Duration) (<-chan map[string]*UnitStatus, <-chan error) {
 	return c.SubscribeUnitsCustom(interval, 0, func(u1, u2 *UnitStatus) bool { return *u1 != *u2 }, nil)


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?