### PR TITLE
dbus: Introduce GetAllProperties() for fetching all systemd unit properties

### DIFF
--- a/dbus/methods.go
+++ b/dbus/methods.go
@@ -197,6 +197,12 @@ func (c *Conn) GetUnitPathProperties(path dbus.ObjectPath) (map[string]interface
 	return c.getProperties(path, "org.freedesktop.systemd1.Unit")
 }
 
+// GetAllProperties takes the (unescaped) unit name and returns all of its dbus object properties.
+func (c *Conn) GetAllProperties(unit string) (map[string]interface{}, error) {
+	path := unitPath(unit)
+	return c.getProperties(path, "")
+}
+
 func (c *Conn) getProperty(unit string, dbusInterface string, propertyName string) (*Property, error) {
 	var err error
 	var prop dbus.Variant


### PR DESCRIPTION
Hi,

I would like to fetch a bunch of systemd service unit properties (e.g. NRestarts, ActiveState, SubState, etc.) in a single call, similar to what I get by running `systemctl show <service>`.

Currently, `dbus/methods.go` exposes two methods for retrieving unit properties:

```
GetUnitTypeProperties(unit string, unitType string)
|-> return c.getProperties(path, "org.freedesktop.systemd1."+unitType) // unitType = Service

GetUnitProperties(unit string)
|-> return c.getProperties(path, "org.freedesktop.systemd1.Unit")
```

Both of these methods call the `getProperties()` helper method:

```
getProperties(path dbus.ObjectPath, dbusInterface string)
|   ...
|-> err = obj.Call("org.freedesktop.DBus.Properties.GetAll", 0, dbusInterface).Store(&props)
```

`getProperties()` will return a different set of properties depending on the `dbusInterface` parameter value (i.e. `org.freedesktop.systemd1.Unit` vs `org.freedesktop.systemd1.Service`). See the `dbus-send` examples below that illustrate this:

```
$ dbus-send --system --dest=org.freedesktop.systemd1 --type=method_call /org/freedesktop/systemd1/unit/<MYSERVICE>_2eservice --print-reply org.freedesktop.DBus.Properties.GetAll string:"org.freedesktop.systemd1.Service" | grep -A 1 -e NRestarts -e ActiveState -e SubState
         string "NRestarts"
         variant             uint32 0
```

```
$ dbus-send --system --dest=org.freedesktop.systemd1 --type=method_call /org/freedesktop/systemd1/unit/<MYSERVICE>_2eservice --print-reply org.freedesktop.DBus.Properties.GetAll string:"org.freedesktop.systemd1.Unit" | grep -A 1 -e NRestarts -e ActiveState -e SubState
         string "ActiveState"
         variant             string "active"
--
         string "SubState"
         variant             string "running"
```

However, if we set the interface argument to an empty string, we get all of these properties in a single call:

```
$ dbus-send --system --dest=org.freedesktop.systemd1 --type=method_call /org/freedesktop/systemd1/unit/<MYSERVICE>_2eservice --print-reply org.freedesktop.DBus.Properties.GetAll string:"" | grep -A 1 -e NRestarts -e ActiveState -e SubState
         string "NRestarts"
         variant             uint32 0
--
         string "ActiveState"
         variant             string "inactive"
--
         string "SubState"
         variant             string "dead"
```

I would like to be able to do the same using this lib by invoking something along the lines of `dbus.GetProperties("<MYSERVICE>.service", "")`
