### PR TITLE
Add go module support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test_bins

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,15 @@ services:
 
 language: go
 go:
-  - "1.10.x"
-  - "1.11.x"
+  - "1.12.x"
+  - "1.13.x"
 go_import_path: github.com/coreos/go-systemd
 
 env:
   global:
     - IMPORTPATH=github.com/coreos/go-systemd
     - GOPATH=/opt
+    - GO111MODULE=on
     - DEP_BINDIR=/tmp
     - BUILD_DIR=/opt/src/github.com/coreos/go-systemd
   matrix:
@@ -23,8 +24,6 @@ env:
 before_install:
  - sudo apt-get -qq update
  - sudo apt-get install -y libsystemd-journal-dev libsystemd-daemon-dev
- - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | INSTALL_DIRECTORY=${DEP_BINDIR} sh
- - ${DEP_BINDIR}/dep ensure -v
  - docker pull ${DOCKER_BASE}
  - docker run --privileged -e GOPATH=${GOPATH} --cidfile=/tmp/cidfile ${DOCKER_BASE} /bin/bash -c "apt-get update && apt-get install -y sudo build-essential git golang dbus libsystemd-dev libpam-systemd systemd-container"
  - docker commit `cat /tmp/cidfile` go-systemd/container-tests

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,7 +1,0 @@
-[[constraint]]
-  name = "github.com/godbus/dbus"
-  version = "5.0"
-
-[prune]
-  go-tests = true
-  unused-packages = true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/coreos/go-systemd.png?branch=master)](https://travis-ci.org/coreos/go-systemd)
 [![godoc](https://godoc.org/github.com/coreos/go-systemd?status.svg)](http://godoc.org/github.com/coreos/go-systemd)
-![minimum golang 1.10](https://img.shields.io/badge/golang-1.10%2B-orange.svg)
+![minimum golang 1.12](https://img.shields.io/badge/golang-1.12%2B-orange.svg)
 
 
 Go bindings to systemd. The project has several packages:

--- a/dbus/dbus.go
+++ b/dbus/dbus.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/dbus/methods.go
+++ b/dbus/methods.go
@@ -20,7 +20,7 @@ import (
 	"path"
 	"strconv"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 func (c *Conn) jobComplete(signal *dbus.Signal) {

--- a/dbus/methods_test.go
+++ b/dbus/methods_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 type TrUnitProp struct {

--- a/dbus/properties.go
+++ b/dbus/properties.go
@@ -15,7 +15,7 @@
 package dbus
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 // From the systemd docs:
@@ -56,7 +56,7 @@ type execStart struct {
 // http://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStart=
 func PropExecStart(command []string, uncleanIsFailure bool) Property {
 	execStarts := []execStart{
-		execStart{
+		{
 			Path:             command[0],
 			Args:             command,
 			UncleanIsFailure: uncleanIsFailure,

--- a/dbus/subscription.go
+++ b/dbus/subscription.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/examples/activation/activation.go
+++ b/examples/activation/activation.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/coreos/go-systemd/activation"
+	"github.com/coreos/go-systemd/v21/activation"
 )
 
 func fixListenPid() {

--- a/examples/activation/httpserver/httpserver.go
+++ b/examples/activation/httpserver/httpserver.go
@@ -20,7 +20,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/coreos/go-systemd/activation"
+	"github.com/coreos/go-systemd/v21/activation"
 )
 
 func HelloServer(w http.ResponseWriter, req *http.Request) {

--- a/examples/activation/listen.go
+++ b/examples/activation/listen.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/coreos/go-systemd/activation"
+	"github.com/coreos/go-systemd/v21/activation"
 )
 
 func fixListenPid() {

--- a/examples/activation/udpconn.go
+++ b/examples/activation/udpconn.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/coreos/go-systemd/activation"
+	"github.com/coreos/go-systemd/v21/activation"
 )
 
 func fixListenPid() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/coreos/go-systemd/v21
+
+go 1.12
+
+require github.com/godbus/dbus/v5 v5.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/godbus/dbus/v5 v5.0.3 h1:ZqHaoEF7TBzh4jzPmqVhE/5A1z9of6orkAe5uHoAeME=
+github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/import1/dbus.go
+++ b/import1/dbus.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/login1/dbus.go
+++ b/login1/dbus.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/machine1/dbus.go
+++ b/machine1/dbus.go
@@ -23,9 +23,9 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 
-	sd_dbus "github.com/coreos/go-systemd/dbus"
+	sd_dbus "github.com/coreos/go-systemd/v21/dbus"
 )
 
 const (

--- a/machine1/dbus_test.go
+++ b/machine1/dbus_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	sd_dbus "github.com/coreos/go-systemd/dbus"
-	"github.com/godbus/dbus"
+	sd_dbus "github.com/coreos/go-systemd/v21/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 const (

--- a/sdjournal/functions.go
+++ b/sdjournal/functions.go
@@ -16,7 +16,7 @@
 package sdjournal
 
 import (
-	"github.com/coreos/go-systemd/internal/dlopen"
+	"github.com/coreos/go-systemd/v21/internal/dlopen"
 	"sync"
 	"unsafe"
 )

--- a/sdjournal/journal_test.go
+++ b/sdjournal/journal_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-systemd/journal"
+	"github.com/coreos/go-systemd/v21/journal"
 )
 
 func TestJournalFollow(t *testing.T) {

--- a/util/util_cgo.go
+++ b/util/util_cgo.go
@@ -58,7 +58,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/coreos/go-systemd/internal/dlopen"
+	"github.com/coreos/go-systemd/v21/internal/dlopen"
 )
 
 var libsystemdNames = []string{


### PR DESCRIPTION
This PR adds a `go.mod` and `go.sum` to the project which contains the latest dependencies. It would be awesome if we could tag a release according to semver after this PR got merged, WDYT? :innocent: 