### PR TITLE
sdjournal: Provide error messages as strings

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -414,7 +414,7 @@ func NewJournal() (j *Journal, err error) {
 	r := C.my_sd_journal_open(sd_journal_open, &j.cjournal, C.SD_JOURNAL_LOCAL_ONLY)
 
 	if r < 0 {
-		return nil, fmt.Errorf("failed to open journal: %d", syscall.Errno(-r))
+		return nil, fmt.Errorf("failed to open journal: %s", syscall.Errno(-r).Error())
 	}
 
 	return j, nil
@@ -435,7 +435,7 @@ func NewJournalFromDir(path string) (j *Journal, err error) {
 
 	r := C.my_sd_journal_open_directory(sd_journal_open_directory, &j.cjournal, p, 0)
 	if r < 0 {
-		return nil, fmt.Errorf("failed to open journal in directory %q: %d", path, syscall.Errno(-r))
+		return nil, fmt.Errorf("failed to open journal in directory %q: %s", path, syscall.Errno(-r).Error())
 	}
 
 	return j, nil
@@ -461,7 +461,7 @@ func NewJournalFromFiles(paths ...string) (j *Journal, err error) {
 
 	r := C.my_sd_journal_open_files(sd_journal_open_files, &j.cjournal, &cPaths[0], 0)
 	if r < 0 {
-		return nil, fmt.Errorf("failed to open journals in paths %q: %d", paths, syscall.Errno(-r))
+		return nil, fmt.Errorf("failed to open journals in paths %q: %s", paths, syscall.Errno(-r).Error())
 	}
 
 	return j, nil
@@ -496,7 +496,7 @@ func (j *Journal) AddMatch(match string) error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to add match: %d", syscall.Errno(-r))
+		return fmt.Errorf("failed to add match: %s", syscall.Errno(-r).Error())
 	}
 
 	return nil
@@ -514,7 +514,7 @@ func (j *Journal) AddDisjunction() error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to add a disjunction in the match list: %d", syscall.Errno(-r))
+		return fmt.Errorf("failed to add a disjunction in the match list: %s", syscall.Errno(-r).Error())
 	}
 
 	return nil
@@ -532,7 +532,7 @@ func (j *Journal) AddConjunction() error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to add a conjunction in the match list: %d", syscall.Errno(-r))
+		return fmt.Errorf("failed to add a conjunction in the match list: %s", syscall.Errno(-r).Error())
 	}
 
 	return nil
@@ -562,7 +562,7 @@ func (j *Journal) Next() (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return 0, fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
+		return 0, fmt.Errorf("failed to iterate journal: %s", syscall.Errno(-r).Error())
 	}
 
 	return uint64(r), nil
@@ -581,7 +581,7 @@ func (j *Journal) NextSkip(skip uint64) (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return 0, fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
+		return 0, fmt.Errorf("failed to iterate journal: %s", syscall.Errno(-r).Error())
 	}
 
 	return uint64(r), nil
@@ -599,7 +599,7 @@ func (j *Journal) Previous() (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return 0, fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
+		return 0, fmt.Errorf("failed to iterate journal: %s", syscall.Errno(-r).Error())
 	}
 
 	return uint64(r), nil
@@ -618,7 +618,7 @@ func (j *Journal) PreviousSkip(skip uint64) (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return 0, fmt.Errorf("failed to iterate journal: %d", syscall.Errno(-r))
+		return 0, fmt.Errorf("failed to iterate journal: %s", syscall.Errno(-r).Error())
 	}
 
 	return uint64(r), nil
@@ -641,7 +641,7 @@ func (j *Journal) getData(field string) (unsafe.Pointer, C.int, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return nil, 0, fmt.Errorf("failed to read message: %d", syscall.Errno(-r))
+		return nil, 0, fmt.Errorf("failed to read message: %s", syscall.Errno(-r).Error())
 	}
 
 	return d, C.int(l), nil
@@ -736,7 +736,7 @@ func (j *Journal) GetEntry() (*JournalEntry, error) {
 	var realtimeUsec C.uint64_t
 	r = C.my_sd_journal_get_realtime_usec(sd_journal_get_realtime_usec, j.cjournal, &realtimeUsec)
 	if r < 0 {
-		return nil, fmt.Errorf("failed to get realtime timestamp: %d", syscall.Errno(-r))
+		return nil, fmt.Errorf("failed to get realtime timestamp: %s", syscall.Errno(-r).Error())
 	}
 
 	entry.RealtimeTimestamp = uint64(realtimeUsec)
@@ -746,7 +746,7 @@ func (j *Journal) GetEntry() (*JournalEntry, error) {
 
 	r = C.my_sd_journal_get_monotonic_usec(sd_journal_get_monotonic_usec, j.cjournal, &monotonicUsec, &boot_id)
 	if r < 0 {
-		return nil, fmt.Errorf("failed to get monotonic timestamp: %d", syscall.Errno(-r))
+		return nil, fmt.Errorf("failed to get monotonic timestamp: %s", syscall.Errno(-r).Error())
 	}
 
 	entry.MonotonicTimestamp = uint64(monotonicUsec)
@@ -757,7 +757,7 @@ func (j *Journal) GetEntry() (*JournalEntry, error) {
 	r = C.my_sd_journal_get_cursor(sd_journal_get_cursor, j.cjournal, &c)
 	defer C.free(unsafe.Pointer(c))
 	if r < 0 {
-		return nil, fmt.Errorf("failed to get cursor: %d", syscall.Errno(-r))
+		return nil, fmt.Errorf("failed to get cursor: %s", syscall.Errno(-r).Error())
 	}
 
 	entry.Cursor = C.GoString(c)
@@ -773,7 +773,7 @@ func (j *Journal) GetEntry() (*JournalEntry, error) {
 		}
 
 		if r < 0 {
-			return nil, fmt.Errorf("failed to read message field: %d", syscall.Errno(-r))
+			return nil, fmt.Errorf("failed to read message field: %s", syscall.Errno(-r).Error())
 		}
 
 		msg := C.GoStringN((*C.char)(d), C.int(l))
@@ -803,7 +803,7 @@ func (j *Journal) SetDataThreshold(threshold uint64) error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to set data threshold: %d", syscall.Errno(-r))
+		return fmt.Errorf("failed to set data threshold: %s", syscall.Errno(-r).Error())
 	}
 
 	return nil
@@ -826,7 +826,7 @@ func (j *Journal) GetRealtimeUsec() (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return 0, fmt.Errorf("failed to get realtime timestamp: %d", syscall.Errno(-r))
+		return 0, fmt.Errorf("failed to get realtime timestamp: %s", syscall.Errno(-r).Error())
 	}
 
 	return uint64(usec), nil
@@ -850,7 +850,7 @@ func (j *Journal) GetMonotonicUsec() (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return 0, fmt.Errorf("failed to get monotonic timestamp: %d", syscall.Errno(-r))
+		return 0, fmt.Errorf("failed to get monotonic timestamp: %s", syscall.Errno(-r).Error())
 	}
 
 	return uint64(usec), nil
@@ -875,7 +875,7 @@ func (j *Journal) GetCursor() (string, error) {
 	defer C.free(unsafe.Pointer(d))
 
 	if r < 0 {
-		return "", fmt.Errorf("failed to get cursor: %d", syscall.Errno(-r))
+		return "", fmt.Errorf("failed to get cursor: %s", syscall.Errno(-r).Error())
 	}
 
 	cursor := C.GoString(d)
@@ -899,7 +899,7 @@ func (j *Journal) TestCursor(cursor string) error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to test to cursor %q: %d", cursor, syscall.Errno(-r))
+		return fmt.Errorf("failed to test to cursor %q: %s", cursor, syscall.Errno(-r).Error())
 	} else if r == 0 {
 		return ErrNoTestCursor
 	}
@@ -921,7 +921,7 @@ func (j *Journal) SeekHead() error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to seek to head of journal: %d", syscall.Errno(-r))
+		return fmt.Errorf("failed to seek to head of journal: %s", syscall.Errno(-r).Error())
 	}
 
 	return nil
@@ -941,7 +941,7 @@ func (j *Journal) SeekTail() error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to seek to tail of journal: %d", syscall.Errno(-r))
+		return fmt.Errorf("failed to seek to tail of journal: %s", syscall.Errno(-r).Error())
 	}
 
 	return nil
@@ -961,7 +961,7 @@ func (j *Journal) SeekRealtimeUsec(usec uint64) error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to seek to %d: %d", usec, syscall.Errno(-r))
+		return fmt.Errorf("failed to seek to %d: %s", usec, syscall.Errno(-r).Error())
 	}
 
 	return nil
@@ -984,7 +984,7 @@ func (j *Journal) SeekCursor(cursor string) error {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return fmt.Errorf("failed to seek to cursor %q: %d", cursor, syscall.Errno(-r))
+		return fmt.Errorf("failed to seek to cursor %q: %s", cursor, syscall.Errno(-r).Error())
 	}
 
 	return nil
@@ -1031,7 +1031,7 @@ func (j *Journal) GetUsage() (uint64, error) {
 	j.mu.Unlock()
 
 	if r < 0 {
-		return 0, fmt.Errorf("failed to get journal disk space usage: %d", syscall.Errno(-r))
+		return 0, fmt.Errorf("failed to get journal disk space usage: %s", syscall.Errno(-r).Error())
 	}
 
 	return uint64(out), nil
@@ -1065,7 +1065,7 @@ func (j *Journal) GetUniqueValues(field string) ([]string, error) {
 	r := C.my_sd_journal_query_unique(sd_journal_query_unique, j.cjournal, f)
 
 	if r < 0 {
-		return nil, fmt.Errorf("failed to query journal: %d", syscall.Errno(-r))
+		return nil, fmt.Errorf("failed to query journal: %s", syscall.Errno(-r).Error())
 	}
 
 	// Implements the SD_JOURNAL_FOREACH_UNIQUE macro from sd-journal.h
@@ -1079,7 +1079,7 @@ func (j *Journal) GetUniqueValues(field string) ([]string, error) {
 		}
 
 		if r < 0 {
-			return nil, fmt.Errorf("failed to read message field: %d", syscall.Errno(-r))
+			return nil, fmt.Errorf("failed to read message field: %s", syscall.Errno(-r).Error())
 		}
 
 		msg := C.GoStringN((*C.char)(d), C.int(l))
@@ -1111,7 +1111,7 @@ func (j *Journal) GetCatalog() (string, error) {
 	defer C.free(unsafe.Pointer(c))
 
 	if r < 0 {
-		return "", fmt.Errorf("failed to retrieve catalog entry for current journal entry: %d", syscall.Errno(-r))
+		return "", fmt.Errorf("failed to retrieve catalog entry for current journal entry: %s", syscall.Errno(-r).Error())
 	}
 
 	catalog := C.GoString(c)


### PR DESCRIPTION
This was previously just displaying the numeric errno value, resulting in error messages like:

```failed to seek to cursor "foo\n": 22```

The `syscall.Errno` type provides a handy function for returning the string value of an error, so just use that for more informative messages.