### PR TITLE
unit: deserialize keeps all semantic data

### DIFF
--- a/unit/deserialize.go
+++ b/unit/deserialize.go
@@ -43,37 +43,99 @@ var (
 	ErrLineTooLong = fmt.Errorf("line too long (max %d bytes)", SYSTEMD_LINE_MAX)
 )
 
-// Deserialize parses a systemd unit file into a list of UnitOption objects.
-func Deserialize(f io.Reader) (opts []*UnitOption, err error) {
-	lexer, optchan, errchan := newLexer(f)
-	go lexer.lex()
-
-	for opt := range optchan {
-		opts = append(opts, &(*opt))
-	}
-
-	err = <-errchan
-	return opts, err
+// DeserializeOptions parses a systemd unit file into a list of UnitOptions
+func DeserializeOptions(f io.Reader) (opts []*UnitOption, err error) {
+	_, options, err := deserializeAll(f)
+	return options, err
 }
 
-func newLexer(f io.Reader) (*lexer, <-chan *UnitOption, <-chan error) {
-	optchan := make(chan *UnitOption)
+// DeserializeSections deserializes into a list of UnitSections.
+func DeserializeSections(f io.Reader) ([]*UnitSection, error) {
+	sections, _, err := deserializeAll(f)
+	return sections, err
+}
+
+// Deserialize parses a systemd unit file into a list of UnitOptions.
+// Note: this function is deprecated in favor of DeserializeOptions
+// and will be removed at a future date.
+func Deserialize(f io.Reader) (opts []*UnitOption, err error) {
+	return DeserializeOptions(f)
+}
+
+type lexDataType int
+
+const (
+	SEC lexDataType = iota
+	OPT
+)
+
+// lexChanData - support either datatype in the lex channel.
+// Poor man's union data type.
+type lexData struct {
+	Type    lexDataType
+	Option  *UnitOption
+	Section *UnitSection
+}
+
+// deserializeAll deserializes into UnitSections and UnitOptions.
+func deserializeAll(f io.Reader) ([]*UnitSection, []*UnitOption, error) {
+
+	lexer, lexchan, errchan := newLexer(f)
+
+	go lexer.lex()
+
+	sections := []*UnitSection{}
+	options := []*UnitOption{}
+
+	for ld := range lexchan {
+		switch ld.Type {
+		case OPT:
+			if ld.Option != nil {
+				// add to options
+				opt := ld.Option
+				options = append(options, &(*opt))
+
+				// sanity check. "should not happen" as SEC is first in code flow.
+				if len(sections) == 0 {
+					return nil, nil, fmt.Errorf(
+						"Unit file misparse: option before section")
+				}
+
+				// add to newest section entries.
+				s := len(sections) - 1
+				sections[s].Entries = append(sections[s].Entries,
+					&UnitEntry{Name: opt.Name, Value: opt.Value})
+			}
+		case SEC:
+			if ld.Section != nil {
+				sections = append(sections, ld.Section)
+			}
+		}
+	}
+
+	err := <-errchan
+
+	return sections, options, err
+}
+
+func newLexer(f io.Reader) (*lexer, <-chan *lexData, <-chan error) {
+	lexchan := make(chan *lexData)
 	errchan := make(chan error, 1)
 	buf := bufio.NewReader(f)
 
-	return &lexer{buf, optchan, errchan, ""}, optchan, errchan
+	return &lexer{buf, lexchan, errchan, ""}, lexchan, errchan
 }
 
 type lexer struct {
 	buf     *bufio.Reader
-	optchan chan *UnitOption
+	lexchan chan *lexData
 	errchan chan error
 	section string
 }
 
 func (l *lexer) lex() {
 	defer func() {
-		close(l.optchan)
+		close(l.lexchan)
 		close(l.errchan)
 	}()
 	next := l.lexNextSection
@@ -124,6 +186,12 @@ func (l *lexer) lexSectionSuffixFunc(section string) lexStep {
 		garbage = bytes.TrimSpace(garbage)
 		if len(garbage) > 0 {
 			return nil, fmt.Errorf("found garbage after section name %s: %v", l.section, garbage)
+		}
+
+		l.lexchan <- &lexData{
+			Type:    SEC,
+			Section: &UnitSection{Section: section, Entries: []*UnitEntry{}},
+			Option:  nil,
 		}
 
 		return l.lexNextSectionOrOptionFunc(section), nil
@@ -252,7 +320,11 @@ func (l *lexer) lexOptionValueFunc(section, name string, partial bytes.Buffer) l
 		} else {
 			val = strings.TrimSpace(val)
 		}
-		l.optchan <- &UnitOption{Section: section, Name: name, Value: val}
+		l.lexchan <- &lexData{
+			Type:    OPT,
+			Section: nil,
+			Option:  &UnitOption{Section: section, Name: name, Value: val},
+		}
 
 		return l.lexNextSectionOrOptionFunc(section), nil
 	}

--- a/unit/section.go
+++ b/unit/section.go
@@ -1,0 +1,44 @@
+// Copyright 2020 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+// UnitEntry is a single line entry in a Unit file.
+type UnitEntry struct {
+	Name  string
+	Value string
+}
+
+// UnitSection is a section in a Unit file. The section name
+// and a list of entries in that section.
+type UnitSection struct {
+	Section string
+	Entries []*UnitEntry
+}
+
+// String implements the stringify interface for UnitEntry
+func (u *UnitEntry) String() string {
+	return "{Name: " + u.Name + ", " + "Value: " + u.Value + "}"
+}
+
+// String implements the stringify interface for UnitSection
+func (s *UnitSection) String() string {
+	result := "{Section: " + s.Section
+	for _, e := range s.Entries {
+		result += e.String()
+	}
+
+	result += "}"
+	return result
+}

--- a/unit/serialize.go
+++ b/unit/serialize.go
@@ -58,6 +58,29 @@ func Serialize(opts []*UnitOption) io.Reader {
 	return &buf
 }
 
+// SerializeSections will serializes the unit file from the given
+// UnitSections.
+func SerializeSections(sections []*UnitSection) io.Reader {
+
+	var buf bytes.Buffer
+
+	for i, s := range sections {
+		writeSectionHeader(&buf, s.Section)
+		writeNewline(&buf)
+
+		for _, e := range s.Entries {
+			writeOption(&buf, &UnitOption{s.Section, e.Name, e.Value})
+			writeNewline(&buf)
+		}
+
+		if i < len(sections)-1 {
+			writeNewline(&buf)
+		}
+	}
+
+	return &buf
+}
+
 func writeNewline(buf *bytes.Buffer) {
 	buf.WriteRune('\n')
 }


### PR DESCRIPTION
The existing unit.Deserialize() function does not contain all the
semantic data in a unit file. Specifically it does not fully
support multiple duplicate sections. It does correctly parse the sections,
but the `[]*UnitOption` data structure does not tell the caller,
in the case of a unit file with duplicate section names, *which*
section the UnitOptions are from.

This may matter.

For example, a `/etc/systemd/network/*.network` file can have multiple
`[Route]` entries. Just returning an array of `Section, Name, Value`
tuples does not tell the caller which `[Route]` a given `Name, Value`
pair belongs to.

Ex:
```
[Route]
Gateway=10.0.100.1
Destination=10.0.0.1/24

[Route]
Gateway=10.0.100.2
Destination=10.0.2.1/24
```

This unit file will generate the following from `unit.Deserialize()`

```
{Section: "Route", Name: "Gateway", Value: "10.0.100.1"}
{Section: "Route", Name: "Destination", Value: "10.0.0.1/24"}
{Section: "Route", Name: "Gateway", Value: "10.0.100.2"}
{Section: "Route", Name: "Destination", Value: "10.0.2.1/24"}
```

With just this information, it is not possible to know which `Gateway`
goes to which `Destination`. Order maybe, but what if there were not two
Gateways? Which `Destination` would go with the `Gateway`?

This patch introduces a new Deserialize function that returns the
following data structures:

```
// UnitEntry is a single line entry in a Unit file.
type UnitEntry struct {
	Name  string
	Value string
}

// UnitSection is a section in a Unit file. The section name
// and a list of entries in that section.
type UnitSection struct {
	Section string
	Entries []*UnitEntry
}
```

The new DeserializeSection() signature is:

```
func DeserializeSections(f io.Reader) ([]*UnitSection, error)
```

And the output from it given the example unit file above is:

```
{Section: Route{Name: Gateway, Value: 10.0.100.1}{Name: Destination, Value: 10.0.0.1/24}}
{Section: Route{Name: Gateway, Value: 10.0.100.2}{Name: Destination, Value: 10.0.2.1/24}}
```

The `Name`, `Value` pairs are directly associated with a specific
section. There is no ambiguity.

There are unit tests added to `unit/deserialize_test.go` that do basic
tests on `DeserializeSections()`. All exising unit tests in that file
are untouched and pass.