### PR TITLE
deserialize: Use quote to print possibly-invalid string

### DIFF
--- a/unit/deserialize.go
+++ b/unit/deserialize.go
@@ -123,7 +123,7 @@ func (l *lexer) lexSectionSuffixFunc(section string) lexStep {
 
 		garbage = bytes.TrimSpace(garbage)
 		if len(garbage) > 0 {
-			return nil, fmt.Errorf("found garbage after section name %s: %v", l.section, garbage)
+			return nil, fmt.Errorf("found garbage after section name %s: %q", l.section, garbage)
 		}
 
 		return l.lexNextSectionOrOptionFunc(section), nil


### PR DESCRIPTION
An openshift/machine-config-operator user wrote an invalid unit,
and printing the contents as a byte array is unnecessary; it's
almost certain to be a valid string, we just found a syntax error.