### PR TITLE
sdjournal: fix input argument type in C.Malloc call

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -1155,7 +1155,7 @@ func (j *Journal) GetBootID() (string, error) {
 		return "", err
 	}
 
-	id128StringMax := C.ulong(C.SD_ID128_STRING_MAX)
+	id128StringMax := C.size_t(C.SD_ID128_STRING_MAX)
 	c := (*C.char)(C.malloc(id128StringMax))
 	defer C.free(unsafe.Pointer(c))
 	C.my_sd_id128_to_string(sd_id128_to_string, boot_id, c)


### PR DESCRIPTION
podman v3.1.0-rc2 uses v22 go-systemd and fedora rpm builds were failing
for 32-bit arches (i686 and armv7hl).

This commit conditionally defines id128StringMax based on
32-bit v/s 64-bit arches.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>
Closes: https://github.com/coreos/go-systemd/issues/363


/cc @vrothberg @ashcrow @mheon @rhatdan