### PR TITLE
gomod: update godbus to v5.0.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/coreos/go-systemd/v22
 
 go 1.12
 
-require github.com/godbus/dbus/v5 v5.0.3
+require github.com/godbus/dbus/v5 v5.0.4

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/godbus/dbus/v5 v5.0.3 h1:ZqHaoEF7TBzh4jzPmqVhE/5A1z9of6orkAe5uHoAeME=
-github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=


### PR DESCRIPTION
Fixes the https://github.com/kubernetes/kubernetes/issues/100328#issuecomment-801741732 needs the patch https://github.com/godbus/dbus/pull/232, now included in v5.0.4.

From v5.0.3 to v5.0.4 mainly some small patches https://github.com/godbus/dbus/compare/v5.0.3...v5.0.4