### PR TITLE
journal: close unix socket after successful probe

### DIFF
--- a/journal/journal_unix.go
+++ b/journal/journal_unix.go
@@ -65,9 +65,11 @@ func Enabled() bool {
 		return false
 	}
 
-	if _, err := net.Dial("unixgram", journalSocket); err != nil {
+	conn, err := net.Dial("unixgram", journalSocket)
+	if err != nil {
 		return false
 	}
+	defer conn.Close()
 
 	return true
 }


### PR DESCRIPTION
This is done to ensure unix sockets aren't left dangling after each Enabled() call, which
can lead to eventual process resource exhaustion. Fixes #366.