### PR TITLE
workflows: limit permissions to reading repo contents

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   GO_TOOLCHAIN: "1.15"
   GOPATH: "/opt"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   # Minimum supported Go toolchain
   ACTION_MINIMUM_TOOLCHAIN: "1.12"


### PR DESCRIPTION
Don't bump the minimum Go version, since there are external projects that depend on this package.