### PR TITLE
dbus: add GetUnitProcessesContext to list any unit's running processes 

### DIFF
--- a/dbus/methods.go
+++ b/dbus/methods.go
@@ -841,12 +841,12 @@ func (c *Conn) ThawUnit(ctx context.Context, unit string) error {
 }
 
 type Process struct {
-	Path    string // The primary unit name as string
-	PID     uint64
-	Command string
+	Path    string // Where this process exists in the unit/cgroup hierarchy
+	PID     uint64 // The numeric process ID (PID)
+	Command string // The process command and arguments as a string
 }
 
-// GetUnitProcessesContext returns an array with all currently running processes in a unit
+// GetUnitProcessesContext returns an array with all currently running processes in a unit *including* its child units.
 func (c *Conn) GetUnitProcessesContext(ctx context.Context, unit string) ([]Process, error) {
 	return c.getUnitProcessesInternal(ctx, unit)
 }

--- a/dbus/methods_test.go
+++ b/dbus/methods_test.go
@@ -1660,7 +1660,7 @@ func TestFreezer(t *testing.T) {
 }
 
 func TestListUnitProcesses(t *testing.T) {
-	target, err := util.CurrentUnitName()
+	target, err := util.GetRunningSlice() // This test should still pass even if the cmd is spawned in a child unit (i.e. session Scope) of the current Slice
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1693,6 +1693,6 @@ func TestListUnitProcesses(t *testing.T) {
 	}
 
 	if !exists {
-		t.Errorf("PID %d ('/bin/sleep 400') not found in current unit's process list", pid)
+		t.Errorf("PID %d ('/bin/sleep 400') not found in current Slice unit's process list", pid)
 	}
 }


### PR DESCRIPTION
This PR adds a binding for `org.freedesktop.systemd1.Manager.GetUnitProcesses`, taking a unit string and returning a list of all processes currently running under that unit (including child units).

This is convenient for getting a lot of information about a Slice's running processes, as it descends into child Slices/Scopes and includes those processes in the list. For example, if we target `user-1000.slice` we can learn about the different `session-*` Scopes under that user and all the processes therein.

My test (which may need adjustments to be more idiomatic/isolated) passes on systemd v239 (RHEL 8), but this Manager method doesn't exist on v219 (RHEL 7). I dug for a bit and can't find the exact version that implemented the GetProcesses API, but it seems to have been around 5 years ago.

This is my first PR here so please let me know how I can fix it! I used existing Manager method bindings as a template, so the code itself should be conformant even if the test needs work.