### PR TITLE
dbus: add support for querying unit by PID

### DIFF
--- a/dbus/methods.go
+++ b/dbus/methods.go
@@ -417,6 +417,24 @@ func (c *Conn) listUnitsInternal(f storeFunc) ([]UnitStatus, error) {
 	return status, nil
 }
 
+func (c *Conn) getUnitInternal(f storeFunc) (string, error) {
+	var result dbus.ObjectPath
+
+	err := f(&result)
+
+	// Nothing in this library actually accepts a dbus.ObjectPath, so it's much
+	// more useful as a name
+	name := unitName(result)
+
+	return name, err
+}
+
+// GetUnitByPIDContext returns the unit name for a given PID. The PID must refer
+// to an existing system process
+func (c *Conn) GetUnitByPIDContext(ctx context.Context, pid uint32) (string, error) {
+	return c.getUnitInternal(c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.GetUnitByPID", 0, pid).Store)
+}
+
 // Deprecated: use ListUnitsContext instead.
 func (c *Conn) ListUnits() ([]UnitStatus, error) {
 	return c.ListUnitsContext(context.Background())

--- a/dbus/methods_test.go
+++ b/dbus/methods_test.go
@@ -450,6 +450,22 @@ func TestReloadOrRestartUnit(t *testing.T) {
 	}
 }
 
+// Ensure that GetUnitByPIDContext works.
+func TestGetUnitByPIDContext(t *testing.T) {
+	conn := setupConn(t)
+	defer conn.Close()
+
+	name, err := conn.GetUnitByPIDContext(context.Background(), 1)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if name == "" {
+		t.Fatal("name is empty")
+	}
+}
+
 // Ensure that ListUnitsByNames works.
 func TestListUnitsByNames(t *testing.T) {
 	target1 := "systemd-journald.service"

--- a/dbus/methods_test.go
+++ b/dbus/methods_test.go
@@ -450,12 +450,28 @@ func TestReloadOrRestartUnit(t *testing.T) {
 	}
 }
 
-// Ensure that GetUnitByPIDContext works.
-func TestGetUnitByPIDContext(t *testing.T) {
+// Ensure that GetUnitByPID works.
+func TestGetUnitByPID(t *testing.T) {
 	conn := setupConn(t)
 	defer conn.Close()
 
-	name, err := conn.GetUnitByPIDContext(context.Background(), 1)
+	path, err := conn.GetUnitByPID(context.Background(), 1)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if path == "" {
+		t.Fatal("path is empty")
+	}
+}
+
+// Ensure that GetUnitNameByPID works.
+func TestGetUnitNameByPID(t *testing.T) {
+	conn := setupConn(t)
+	defer conn.Close()
+
+	name, err := conn.GetUnitNameByPID(context.Background(), 1)
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
This exposes the functionality of the `GetUnitByPID` method and could be useful in situations where you're trying to find which unit owns a given process.

I chose to convert from `dbus.ObjectPath` to a `string` (the name of the unit) since almost nothing in this library accepts an `dbus.ObjectPath` as an input, and the methods for converting back and forth are private and not available to users. The current output format could then be passed into `ListUnitsByNames` in order to get further information.