### PR TITLE
Add new follow method

### DIFF
--- a/sdjournal/read.go
+++ b/sdjournal/read.go
@@ -256,8 +256,8 @@ process:
 	}
 }
 
-// FollowTail synchronously follows the JournalReader, writing each new journal entry to writer. The
-// follow will continue until a single time.Time is received on the until channel.
+// FollowTail synchronously follows the JournalReader, writing each new journal entry to entries.
+// It will start from the next unread entry.
 func (r *JournalReader) FollowTail(entries chan *JournalEntry) error {
 	defer close(entries)
 

--- a/sdjournal/read.go
+++ b/sdjournal/read.go
@@ -256,15 +256,24 @@ process:
 	}
 }
 
+// SkipN skips the next n entries and returns the number of skipped entries and an eventual error.
+func (r *JournalReader) SkipN(n int) (int, error) {
+	var i int
+	for i := 1; i <= n; i++ {
+		c, err := r.journal.Next()
+		if err != nil {
+			return i, err
+		} else if c == 0 {
+			return i, nil
+		}
+	}
+	return i, nil
+}
+
 // FollowTail synchronously follows the JournalReader, writing each new journal entry to entries.
 // It will start from the next unread entry.
 func (r *JournalReader) FollowTail(entries chan *JournalEntry) error {
 	defer close(entries)
-
-	// skip first entry which has already been read
-	if _, err := r.journal.Next(); err != nil {
-		return err
-	}
 
 	for {
 		status := r.journal.Wait(200 * time.Millisecond)


### PR DESCRIPTION
First, thanks a lot for providing this interface to systemd, I currently use it to synchronise the journal of multiple devices with an external remote.

The recent follow method didn't work as I wanted it for my use case to due to various reasons:
* After each wait, only one one journal entry was written to the writer
    * So, if more than one entry adds to the journal within the specified 100ms, the journal stays behind the tail
* The formatter hook is quite extensible, but channels might give slightly higher flexibility
* Skipping entries manually from outside is not possible