### PR TITLE
login1: Use blackbox testing

### DIFF
--- a/login1/dbus_test.go
+++ b/login1/dbus_test.go
@@ -12,26 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package login1
+package login1_test
 
 import (
 	"fmt"
 	"os/user"
 	"regexp"
 	"testing"
+
+	"github.com/coreos/go-systemd/v22/login1"
 )
 
 // TestNew ensures that New() works without errors.
 func TestNew(t *testing.T) {
-	_, err := New()
-
-	if err != nil {
+	if _, err := login1.New(); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestListSessions(t *testing.T) {
-	c, err := New()
+	c, err := login1.New()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func TestListSessions(t *testing.T) {
 }
 
 func TestListUsers(t *testing.T) {
-	c, err := New()
+	c, err := login1.New()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is a desired way of testing to avoid creating fragile test suites
and be able to refactor code without touching tests.

Extracted from #390

Signed-off-by: Mateusz Gozdek <mgozdek@microsoft.com>