### PR TITLE
ci: add testing using 1.16/1.17/1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.14', '1.15']
+        go: ['1.14', '1.15', '1.16', '1.17', '1.18']
     steps:
       - run: sudo apt-get -qq update
       - name: Install libsystemd-dev

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,6 @@
 ---
 name: Go
-on:
+"on":
   push:
     branches: [main]
   pull_request:
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.14', '1.15', '1.16', '1.17', '1.18']
+        go: ['1.17', '1.18']
     steps:
       - run: sudo apt-get -qq update
       - name: Install libsystemd-dev

--- a/activation/files_unix.go
+++ b/activation/files_unix.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 // Package activation implements primitives for systemd socket activation.

--- a/examples/activation/activation.go
+++ b/examples/activation/activation.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build ignore
 // +build ignore
 
 // Activation example used by the activation unit tests.

--- a/examples/activation/httpserver/httpserver.go
+++ b/examples/activation/httpserver/httpserver.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/examples/activation/listen.go
+++ b/examples/activation/listen.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build ignore
 // +build ignore
 
 // Activation example used by the activation unit tests.

--- a/examples/activation/udpconn.go
+++ b/examples/activation/udpconn.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build ignore
 // +build ignore
 
 // Activation example used by the activation unit tests.

--- a/util/util_cgo.go
+++ b/util/util_cgo.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build cgo
 // +build cgo
 
 package util

--- a/util/util_stub.go
+++ b/util/util_stub.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !cgo
 // +build !cgo
 
 package util


### PR DESCRIPTION
This expands the matrix of Go versions that are being tested with each PR.

In order to support 1.17+, the build constraints had to be updated to make `gofmt` happy.