### PR TITLE
internal/dlopen: fix test and run in CI

### DIFF
--- a/internal/dlopen/dlopen_example.go
+++ b/internal/dlopen/dlopen_example.go
@@ -1,0 +1,57 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//go:build linux
+// +build linux
+
+package dlopen
+
+// #include <string.h>
+// #include <stdlib.h>
+//
+// int
+// my_strlen(void *f, const char *s)
+// {
+//   size_t (*strlen)(const char *);
+//
+//   strlen = (size_t (*)(const char *))f;
+//   return strlen(s);
+// }
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+func strlen(libs []string, s string) (int, error) {
+	h, err := GetHandle(libs)
+	if err != nil {
+		return -1, fmt.Errorf(`couldn't get a handle to the library: %v`, err)
+	}
+	defer h.Close()
+
+	f := "strlen"
+	cs := C.CString(s)
+	defer C.free(unsafe.Pointer(cs))
+
+	strlen, err := h.GetSymbolPointer(f)
+	if err != nil {
+		return -1, fmt.Errorf(`couldn't get symbol %q: %v`, f, err)
+	}
+
+	len := C.my_strlen(strlen, cs)
+
+	return int(len), nil
+}

--- a/scripts/ci-runner.sh
+++ b/scripts/ci-runner.sh
@@ -6,7 +6,7 @@ PROJ="go-systemd"
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/${PROJ}"
 
-PACKAGES="activation daemon dbus journal login1 machine1 sdjournal unit util import1"
+PACKAGES="activation daemon dbus internal/dlopen journal login1 machine1 sdjournal unit util import1"
 EXAMPLES="activation listen udpconn"
 
 function build_source {


### PR DESCRIPTION
This adds one missing file that was forgotten during the initial porting. Without that, the test could not even be built.
The internal package is now also properly tested by CI.

Source file is taken verbatim from https://github.com/coreos/pkg/tree/c7d1c02cb6cf99162b9cdbcad2a6a5c10af2ddca/dlopen.

Fixes: https://github.com/coreos/go-systemd/issues/339