### PR TITLE
workflows: add Go 1.20, switch to setup-go v4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,7 +25,7 @@ jobs:
         run: sudo apt-get install libsystemd-dev
       - uses: actions/checkout@v3
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
       - name: Go fmt
@@ -45,7 +45,7 @@ jobs:
         run: sudo apt-get install libsystemd-dev
       - uses: actions/checkout@v3
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env['ACTION_MINIMUM_TOOLCHAIN'] }}
       - name: Go fmt

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17.x', '1.18.x', '1.19.x']
+        go: ['1.17.x', '1.18.x', '1.19.x', '1.20.x']
     steps:
       - run: sudo apt-get -qq update
       - name: Install libsystemd-dev


### PR DESCRIPTION
Cache dependencies and build outputs by default.