### PR TITLE
workflows: update Linux distro versions; update actions; add Go 1.20

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   ditro-test:
     name: "Distro test"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         baseimage: ['debian:bullseye', 'ubuntu:20.04', 'ubuntu:22.04']

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        baseimage: ['debian:stretch', 'ubuntu:18.04', 'ubuntu:20.04']
+        baseimage: ['debian:bullseye', 'ubuntu:18.04', 'ubuntu:20.04']
     steps:
       - run: sudo apt-get -qq update
       - name: Install libsystemd-dev

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo apt-get install libsystemd-dev
       - uses: actions/checkout@v3
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env['GO_TOOLCHAIN'] }}
       - name: Go build (source)

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        baseimage: ['debian:bullseye', 'ubuntu:18.04', 'ubuntu:20.04']
+        baseimage: ['debian:bullseye', 'ubuntu:20.04', 'ubuntu:22.04']
     steps:
       - run: sudo apt-get -qq update
       - name: Install libsystemd-dev

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -26,7 +26,7 @@ jobs:
       - run: sudo apt-get -qq update
       - name: Install libsystemd-dev
         run: sudo apt-get install libsystemd-dev
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup go
         uses: actions/setup-go@v1
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,7 +25,7 @@ jobs:
         run: sudo apt-get install libsystemd-dev
       - uses: actions/checkout@v3
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
       - name: Go fmt
@@ -45,7 +45,7 @@ jobs:
         run: sudo apt-get install libsystemd-dev
       - uses: actions/checkout@v3
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env['ACTION_MINIMUM_TOOLCHAIN'] }}
       - name: Go fmt

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17.x', '1.18.x', '1.19.x']
+        go: ['1.17.x', '1.18.x', '1.19.x', '1.20.x']
     steps:
       - run: sudo apt-get -qq update
       - name: Install libsystemd-dev


### PR DESCRIPTION
Use non-EOL Linux distro versions, and build test binaries on a sufficiently old GitHub runner image to be compatible with those distros.

Also bump checkout and setup-go actions and add Go 1.20.