### PR TITLE
dlopen: make error handling thread safe

### DIFF
--- a/internal/dlopen/dlopen.go
+++ b/internal/dlopen/dlopen.go
@@ -23,6 +23,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"unsafe"
 )
 
@@ -56,6 +57,10 @@ func GetHandle(libs []string) (*LibHandle, error) {
 
 // GetSymbolPointer takes a symbol name and returns a pointer to the symbol.
 func (l *LibHandle) GetSymbolPointer(symbol string) (unsafe.Pointer, error) {
+	// Locking the thread is critical here as the dlerror() is thread local so
+	// go should not reschedule this onto another thread.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	sym := C.CString(symbol)
 	defer C.free(unsafe.Pointer(sym))
 
@@ -71,6 +76,10 @@ func (l *LibHandle) GetSymbolPointer(symbol string) (unsafe.Pointer, error) {
 
 // Close closes a LibHandle.
 func (l *LibHandle) Close() error {
+	// Locking the thread is critical here as the dlerror() is thread local so
+	// go should not reschedule this onto another thread.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	C.dlerror()
 	C.dlclose(l.Handle)
 	e := C.dlerror()


### PR DESCRIPTION
The dlerror() value is stored in thread local storage and thus checking the error from go code is not safe because go can schedule goroutines on any other thread at any time. This means it is possible that between the dlsym() or dlclose() call the code get moved to another thread and thus the dlerror() value is not what we expect. Instead because we read now from another thread it will be an error from a different call.

A test is added which without this fix is able to reproduce the problem somewhat reliably.

This issue was observed in the podman CI[1] which uses the sdjournal API.

[1] https://github.com/containers/podman/issues/20569