### PR TITLE
activation: stub out for plan9

### DIFF
--- a/activation/files_stub.go
+++ b/activation/files_stub.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows || plan9
+// +build windows plan9
+
 package activation
 
 import "os"

--- a/activation/files_unix.go
+++ b/activation/files_unix.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !plan9
+// +build !windows,!plan9
 
 // Package activation implements primitives for systemd socket activation.
 package activation


### PR DESCRIPTION
plan9 doesn't have syscall.CloseOnExec, causing anything using `activation` to fail when building on plan9:

```
2024/05/03 12:12:51 Failed to run [go build --ldflags -s -X github.com/rclone/rclone/fs.Version=v1.67.0-beta.7911.f8ce568ca.merge -trimpath -o rclone-v1.67.0-beta.7911.f8ce568ca.merge-plan9-386/rclone -tags  ..]: exit status 1
2024/05/03 12:12:51 Command output was:
Error: ../../../../go/pkg/mod/github.com/coreos/go-systemd/v22@v22.5.0/activation/files_unix.go:60:11: undefined: syscall.CloseOnExec
```

Seen on https://github.com/rclone/rclone/pull/7801