### PR TITLE
add FilesWithNames() to activation

### DIFF
--- a/activation/files_unix.go
+++ b/activation/files_unix.go
@@ -68,3 +68,22 @@ func Files(unsetEnv bool) []*os.File {
 
 	return files
 }
+
+// FilesWithNames maps fd names to a set of os.File pointers.
+func FilesWithNames() map[string][]*os.File {
+	files := activation.Files(true)
+	filesWithNames := map[string][]*os.File{}
+
+	for _, f := range files {
+		current, ok := filesWithNames[f.Name()]
+
+		if !ok {
+			current = []*os.File{}
+			filesWithNames[f.Name()] = current
+		}
+
+		filesWithNames[f.Name()] = append(current, f)
+	}
+
+	return filesWithNames
+}


### PR DESCRIPTION
I'd like to upstream the function here https://github.com/MayCXC/caddy-systemd-socket-activation/blob/master/networks.go#L25

which is like the `*WithNames` funcs here https://github.com/coreos/go-systemd/blob/main/activation/listeners.go , but with the benefit that it works for any network (tcp/udp/unix/unixgram/etc.) that a socket might be bound to, and lets the caller choose how to make a FileListener or FilePacketConn from them.