### PR TITLE
add missing return of properties in DescribeMachine

### DIFF
--- a/machine1/dbus.go
+++ b/machine1/dbus.go
@@ -163,7 +163,7 @@ func (c *Conn) DescribeMachine(name string) (machineProps map[string]interface{}
 	for key, val := range dbusProps {
 		machineProps[key] = val.Value()
 	}
-	return
+	return machineProps, nil
 }
 
 // KillMachine sends a signal to a machine

--- a/machine1/dbus_test.go
+++ b/machine1/dbus_test.go
@@ -125,6 +125,14 @@ func TestMachine(t *testing.T) {
 	}
 
 	for _, v := range machineNames {
+		props, err := conn.DescribeMachine(v)
+		if err != nil {
+			t.Fatal("failed to get machine properties")
+		}
+		t.Logf("machine %s properties: %v", v, props)
+		if len(props) == 0 {
+			t.Fatalf("no machine properties found for %s", v)
+		}
 		tErr := conn.TerminateMachine(v)
 		if tErr != nil {
 			t.Fatal(tErr)


### PR DESCRIPTION
This commit fixes a bug where `machineProps` was not returned.
I added some logic to the unit test:

```
$ sudo go test -v
=== RUN   TestMachine
    dbus_test.go:132: machine machined-test-register-gkkxchal properties: map[Class:container Id:[] Leader:435704 Name:machined-test-register-gkkxchal NetworkInterfaces:[] RootDirectory: Service:go-systemd State:running Timestamp:1728652846963827 TimestampMonotonic:6097688654967 Unit:machined-test-register-gkkxchal.service]
    dbus_test.go:132: machine machined-test-register-with-network-bfeyiref properties: map[Class:container Id:[] Leader:435706 Name:machined-test-register-with-network-bfeyiref NetworkInterfaces:[] RootDirectory: Service:go-systemd State:running Timestamp:1728652846964826 TimestampMonotonic:6097688655967 Unit:machined-test-register-with-network-bfeyiref.service]
    dbus_test.go:132: machine machined-test-create-thdkckgj properties: map[Class:container Id:[] Leader:435708 Name:machined-test-create-thdkckgj NetworkInterfaces:[] RootDirectory: Service:go-systemd State:running Timestamp:1728652846966834 TimestampMonotonic:6097688657975 Unit:machine-machined\x2dtest\x2dcreate\x2dthdkckgj.scope]
    dbus_test.go:132: machine machined-test-create-with-network-mkqmytyw properties: map[Class:container Id:[] Leader:435710 Name:machined-test-create-with-network-mkqmytyw NetworkInterfaces:[] RootDirectory: Service:go-systemd State:running Timestamp:1728652846972931 TimestampMonotonic:6097688664072 Unit:machine-machined\x2dtest\x2dcreate\x2dwith\x2dnetwork\x2dmkqmytyw.scope]
--- PASS: TestMachine (0.13s)
=== RUN   TestImages
--- PASS: TestImages (0.00s)
PASS
ok      github.com/coreos/go-systemd/v22/machine1       0.134s
```