### PR TITLE
dbus: add AttachProcessesToUnit

### DIFF
--- a/dbus/methods.go
+++ b/dbus/methods.go
@@ -862,3 +862,8 @@ func (c *Conn) FreezeUnit(ctx context.Context, unit string) error {
 func (c *Conn) ThawUnit(ctx context.Context, unit string) error {
 	return c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.ThawUnit", 0, unit).Store()
 }
+
+// AttachProcessesToUnit moves existing processes, identified by pids, into an existing systemd unit.
+func (c *Conn) AttachProcessesToUnit(ctx context.Context, unit, subcgroup string, pids []uint32) error {
+	return c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.AttachProcessesToUnit", 0, unit, subcgroup, pids).Store()
+}

--- a/fixtures/attach-processes.service
+++ b/fixtures/attach-processes.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=attach processes test
+
+[Service]
+Delegate=yes
+ExecStart=/bin/sleep 400


### PR DESCRIPTION
The functionality is available since systemd v238 (see https://github.com/systemd/systemd/pull/8125/commits/6592b9759cae509b407a3b49603498468bf5d276) but was never exposed to go-systemd.

This is to be used by opencontainers/cgroups packages (see https://github.com/opencontainers/cgroups/pull/26) and eventually runc (see https://github.com/opencontainers/runc/pull/4822).