### PR TITLE
Bump go to 1.23, fix tests, add more images

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -18,10 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         baseimage: ['debian:bullseye', 'ubuntu:20.04', 'ubuntu:22.04']
+        go: [1.23, 1.24]
     steps:
       - uses: actions/checkout@v4
       - name: Run tests in container
-        run: ./scripts/ci-runner.sh run_in_ct ${{ matrix.baseimage }}
+        run: ./scripts/ci-runner.sh run_in_ct ${{ matrix.baseimage }} ${{ matrix.go }}
 
   all-done:
     needs:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        baseimage: ['debian:bullseye', 'ubuntu:20.04', 'ubuntu:22.04']
+        baseimage: ['debian:bullseye', 'debian:trixie', 'ubuntu:20.04', 'ubuntu:24.04', 'fedora']
         go: [1.23, 1.24]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -20,27 +20,8 @@ jobs:
         baseimage: ['debian:bullseye', 'ubuntu:20.04', 'ubuntu:22.04']
     steps:
       - uses: actions/checkout@v4
-      - name: Pull base image - ${{ matrix.baseimage }}
-        run: docker pull ${{ matrix.baseimage }}
-      - name: Install packages for ${{ matrix.baseimage }}
-        run: docker run --privileged --cidfile=/tmp/cidfile ${{ matrix.baseimage }} /bin/bash -e -c "export DEBIAN_FRONTEND=noninteractive; apt-get update; apt-get install -y sudo build-essential git golang dbus libsystemd-dev libpam-systemd systemd-container"
-      - name: Persist base container
-        run: |
-          docker commit `cat /tmp/cidfile` go-systemd/container-tests
-          docker rm -f `cat /tmp/cidfile`
-          rm -f /tmp/cidfile
-      - name: Run systemd from ${{ matrix.baseimage }}
-        run: docker run --shm-size=2gb -d --cidfile=/tmp/cidfile --privileged -v ${PWD}:/src go-systemd/container-tests /bin/systemd --system
-      - name: Fixup git
-        run: docker exec --privileged `cat /tmp/cidfile` /bin/bash -e -c 'git config --global --add safe.directory /src'
-      - name: Build tests
-        run: docker exec --privileged `cat /tmp/cidfile` /bin/bash -e -c 'cd /src; ./scripts/ci-runner.sh build_tests'
-      - name: Wait a bit for the whole system to settle
-        run: sleep 30s
-      - name: Run tests
-        run: docker exec --privileged `cat /tmp/cidfile` /bin/bash -e -c 'cd /src; ./scripts/ci-runner.sh run_tests'
-      - name: Cleanup
-        run: docker kill `cat /tmp/cidfile`
+      - name: Run tests in container
+        run: ./scripts/ci-runner.sh run_in_ct ${{ matrix.baseimage }}
 
   all-done:
     needs:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.12.x', '1.23.x', '1.24.x']
+        go: ['1.23.x', '1.24.x']
     steps:
       - run: sudo apt-get -qq update
       - name: Install libsystemd-dev

--- a/fixtures/oneshot.service
+++ b/fixtures/oneshot.service
@@ -1,7 +1,6 @@
 [Unit]
-Description=start stop test
+Description=list jobs test
 
 [Service]
-ExecStart=/bin/sh sleep 400
-ExecStopPost=/bin/sh sleep 1000
 Type=oneshot
+ExecStart=/bin/sleep 30

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/coreos/go-systemd/v22
 
-go 1.12
+go 1.23
 
 require github.com/godbus/dbus/v5 v5.1.0

--- a/login1/dbus_test.go
+++ b/login1/dbus_test.go
@@ -53,7 +53,7 @@ func TestListSessions(t *testing.T) {
 				t.Fatalf("expected uid '%d' but got '%s'", s.UID, lookup.Uid)
 			}
 
-			validPath := regexp.MustCompile(`/org/freedesktop/login1/session/_[0-9]+`)
+			validPath := regexp.MustCompile(`/org/freedesktop/login1/session/[_c][0-9]+`)
 			if !validPath.MatchString(fmt.Sprint(s.Path)) {
 				t.Fatalf("invalid session path: %s", s.Path)
 			}

--- a/scripts/ci-runner.sh
+++ b/scripts/ci-runner.sh
@@ -39,10 +39,14 @@ function run_in_ct {
     set -x
     docker pull "$image"
     docker run -i --privileged --cidfile="$cidfile" "$image" /bin/bash -e -x << EOF
-export DEBIAN_FRONTEND=noninteractive
-apt-get -qq update
-apt-get -qq install -y -o Dpkg::Use-Pty=0 \
+if dpkg --version; then
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get -qq update
+    apt-get -qq install -y -o Dpkg::Use-Pty=0 \
 	sudo build-essential curl git dbus libsystemd-dev libpam-systemd systemd-container
+else # Assuming Fedora
+    dnf install -qy sudo curl gcc git dbus systemd-devel systemd-container
+fi
 # Fixup git.
 git config --global --add safe.directory /src
 # Install Go.
@@ -57,7 +61,7 @@ EOF
     docker rm -f "$cid"
 
     echo "Starting a container with systemd..."
-    docker run --shm-size=2gb -d --cidfile="$cidfile" --privileged -v "${PWD}:/src" "$name" /bin/systemd --system
+    docker run --shm-size=2gb -d --cidfile="$cidfile" --privileged -v "${PWD}:/src" "$name" /sbin/init --system
     cid=$(cat "$cidfile")
     rm -f "$cidfile"
     docker exec --privileged "$cid" /bin/bash -e -c 'cd /src; ./scripts/ci-runner.sh build_tests'

--- a/scripts/ci-runner.sh
+++ b/scripts/ci-runner.sh
@@ -34,7 +34,8 @@ function run_in_ct {
     docker run -i --privileged --cidfile="$cidfile" "$image" /bin/bash -e -x << EOF
 export DEBIAN_FRONTEND=noninteractive
 apt-get -qq update
-apt-get -qq install -y sudo build-essential git golang dbus libsystemd-dev libpam-systemd systemd-container
+apt-get -qq install -y -o Dpkg::Use-Pty=0 \
+	sudo build-essential git golang dbus libsystemd-dev libpam-systemd systemd-container
 # Fixup git.
 git config --global --add safe.directory /src
 EOF

--- a/sdjournal/journal_test.go
+++ b/sdjournal/journal_test.go
@@ -453,12 +453,29 @@ func TestJournalGetCatalog(t *testing.T) {
 		t.Fatalf("Error adding matches to journal: %s", err)
 	}
 
-	if err = waitAndNext(j); err != nil {
-		t.Fatalf(err.Error())
+	// Look for an entry with MESSAGE_ID (required for GetCatalog).
+	found := false
+	for range 100 {
+		n, err := j.Next()
+		if err != nil {
+			t.Fatalf("Error reading journal: %s", err)
+		}
+		if n == 0 {
+			break
+		}
+
+		// Check if this entry has a MESSAGE_ID
+		if _, err := j.GetData("MESSAGE_ID"); err == nil {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Skip("No journal entries with MESSAGE_ID found for systemd-journald.service")
 	}
 
 	catalog, err := j.GetCatalog()
-
 	if err != nil {
 		t.Fatalf("Failed to retrieve catalog entry: %s", err)
 	}

--- a/sdjournal/journal_test.go
+++ b/sdjournal/journal_test.go
@@ -488,7 +488,7 @@ func TestJournalGetBootID(t *testing.T) {
 		t.Fatalf("Get bootID: %s is Null", bootID)
 	}
 
-	fmt.Printf("Test GetBootID: %s", bootID)
+	t.Log("bootid:", bootID)
 }
 
 func contains(s []string, v string) bool {


### PR DESCRIPTION
Please see individual commits for details.

High level overview:
- move container setup logic to a script
- make apt-get install less verbose
- install known go version in containers
- go.mod: bump go to 1.23
- TestListJobs: fix flakiness
- login1: fix TestListSessions vs new systemd
- sdjournal: don't use fmt.Printf from tests
- djournal/TestJournalGetCatalog: fix vs new systemd
- add more images (newer ubuntu, debian, fedora)

These are moved to a followup PR:
- Replace interface{} with any
- Use for range for integers
- sdjournal/journal_test.go: use slices.Contains
- login1: remove unused method
- sdjournal,machine1: don't use rand.Seed in test
- Remove io/ioutil usage