### PR TITLE
README: bump minimal Go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-systemd
 
 [![godoc](https://img.shields.io/badge/godoc-reference-5272B4)](https://pkg.go.dev/mod/github.com/coreos/go-systemd/v22/?tab=packages)
-![minimum golang 1.12](https://img.shields.io/badge/golang-1.12%2B-orange.svg)
+![minimum golang 1.23](https://img.shields.io/badge/golang-1.23%2B-orange.svg)
 
 
 Go bindings to systemd. The project has several packages:


### PR DESCRIPTION
This is an addition to commit 73f6754 ("go.mod: bump go to 1.23").