### PR TITLE
activation: allow building without tls support

### DIFF
--- a/activation/listeners.go
+++ b/activation/listeners.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_listeners
+
 package activation
 
 import (


### PR DESCRIPTION
When listeners.go APIs are not used by a given application, golang
doesn't automatically optimize them out. Add an opt-out build tag to
activation/listeners.go, such that one can build an application that
uses activation files without the listeners APIs.

For applications that do not already include any "crypto/tls" this can
be highly beneficial, for example runc can reduce it's total binary
size by 7.6%.

runc project already uses go mod vendor, and can just delete the listeners.go file:
- https://github.com/opencontainers/runc/pull/5056

But it would be preffered if this opt-out build-tag was available here
upstream for people to use in general.
