### PR TITLE
machine1: add missing close method to conn.

### DIFF
--- a/machine1/dbus.go
+++ b/machine1/dbus.go
@@ -113,6 +113,11 @@ func (c *Conn) getPath(method string, args ...any) (dbus.ObjectPath, error) {
 	return path, nil
 }
 
+// Close the underlying dbus connection
+func (c *Conn) Close() error {
+	return c.conn.Close()
+}
+
 // Connected returns whether conn is connected
 func (c *Conn) Connected() bool {
 	return c.conn.Connected()


### PR DESCRIPTION
machine1.Conn was missing a Close method.