### PR TITLE
dbus: fix TestSetUnitProperties wrt systemd >= 252

### DIFF
--- a/dbus/methods_test.go
+++ b/dbus/methods_test.go
@@ -842,9 +842,13 @@ func TestSetUnitProperties(t *testing.T) {
 	conn := setupConn(t)
 	defer conn.Close()
 
-	unit := "-.mount"
+	const (
+		unit      = "-.mount"
+		propName  = "TasksMax"
+		propValue = uint64(98765)
+	)
 
-	if err := conn.SetUnitProperties(unit, true, Property{"CPUShares", dbus.MakeVariant(uint64(1023))}); err != nil {
+	if err := conn.SetUnitProperties(unit, true, Property{propName, dbus.MakeVariant(propValue)}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -853,9 +857,9 @@ func TestSetUnitProperties(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	value, _ := info["CPUShares"].(uint64)
-	if value != 1023 {
-		t.Fatal("CPUShares of unit is not 1023:", value)
+	value, _ := info[propName].(uint64)
+	if value != propValue {
+		t.Fatalf("Expected %s=%d, got %d", propName, propValue, value)
 	}
 }
 


### PR DESCRIPTION
Since systemd 252, some cgroup v1 unit properties are fully deprecated and are ignored. This includes CPUShares that is used by TestSetUnitProperties. As a result, the test fails.

Reproduced on Fedora 43 with systemd 258:

	# systemctl set-property -- '-.mount' CPUShares=1024
	D-Bus property CPUShares is deprecated, ignoring assignment: CPUShares=1024
	# systemctl show -- -.mount | grep Shares
	(no output)

To fix the test failure, replace CPUShares with TasksMax, which is supported since systemd 227 and available for both cgroups v1 and v2.