### PR TITLE
activation: simplify ListenersWithNames

### DIFF
--- a/activation/listeners.go
+++ b/activation/listeners.go
@@ -45,12 +45,7 @@ func ListenersWithNames() (map[string][]net.Listener, error) {
 
 	for _, f := range files {
 		if pc, err := net.FileListener(f); err == nil {
-			current, ok := listeners[f.Name()]
-			if !ok {
-				listeners[f.Name()] = []net.Listener{pc}
-			} else {
-				listeners[f.Name()] = append(current, pc)
-			}
+			listeners[f.Name()] = append(listeners[f.Name()], pc)
 			f.Close()
 		}
 	}


### PR DESCRIPTION
As map lookup returns nil if no key is found, and append will create a new slice if it's first argument is nil, we can greatly simplify the loop, as suggested in [1].

[1]: https://github.com/coreos/go-systemd/pull/448#discussion_r2676299340