### PR TITLE
add CancelJob()

### DIFF
--- a/dbus/methods.go
+++ b/dbus/methods.go
@@ -718,6 +718,11 @@ func (c *Conn) ListJobsContext(ctx context.Context) ([]JobStatus, error) {
 	return storeSlice[JobStatus](c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.ListJobs", 0).Store)
 }
 
+// CancelJob cancels the specified job ID.
+func (c *Conn) CancelJob(ctx context.Context, id uint32) error {
+	return c.sysobj.CallWithContext(ctx, "org.freedesktop.systemd1.Manager.CancelJob", 0, id).Store()
+}
+
 // FreezeUnit freezes the cgroup associated with the unit.
 // Note that FreezeUnit and [Conn.ThawUnit] are only supported on systems running with cgroup v2.
 func (c *Conn) FreezeUnit(ctx context.Context, unit string) error {

--- a/dbus/methods_test.go
+++ b/dbus/methods_test.go
@@ -1884,3 +1884,40 @@ func TestStopUnitReentrant(t *testing.T) {
 		t.Fatal("JobListener jobs leaked")
 	}
 }
+
+func TestCancel(t *testing.T) {
+	target := "cancelme.service"
+	conn := setupConn(t)
+	defer conn.Close()
+
+	setupUnit(target, conn, t)
+	linkUnit(target, conn, t)
+
+	reschan := make(chan string)
+	_, err := conn.StartUnit(target, "replace", reschan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	units, err := conn.ListUnitsByNamesContext(t.Context(), []string{target})
+	if err != nil {
+		t.Fatal("couldn't list units ", err)
+	}
+
+	if err := conn.CancelJob(t.Context(), units[0].JobId); err != nil {
+		t.Fatal("couldn't cancel job ", err)
+	}
+
+	units, err = conn.ListUnitsByNamesContext(t.Context(), []string{target})
+	if err != nil {
+		t.Fatal("couldn't list units after cancel ", err)
+	}
+	if units[0].JobId != 0 {
+		t.Fatal("expected no active job after cancel, got JobId:", units[0].JobId)
+	}
+
+	job := <-reschan
+	if job != "canceled" {
+		t.Fatal("Job is not canceled:", job)
+	}
+}

--- a/fixtures/cancelme.service
+++ b/fixtures/cancelme.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=cancel unit test
+
+[Service]
+ExecStartPre=/bin/sleep 400
+ExecStart=/bin/sleep 400


### PR DESCRIPTION
We'd like to be able to cancel jobs using this API, so add a wrapper for it.

----

Rebased version of https://github.com/coreos/go-systemd/pull/426