### PR TITLE
update golangci-lint to v2.10.1

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,7 +41,7 @@ jobs:
           go-version: stable
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.7
+          version: v2.10.1
 
   all-done:
     needs:


### PR DESCRIPTION
The older version does not support go 1.26 but the workflow installs go 1.26 as it ask for the stable go version. Therefore CI fails currently. Fix this by updating golangci-lint to the latest version which does support go 1.26.