### PR TITLE
scripts/ci-runner.sh: wait for systemd to settle

### DIFF
--- a/scripts/ci-runner.sh
+++ b/scripts/ci-runner.sh
@@ -65,10 +65,8 @@ EOF
     docker run --shm-size=2gb -d --cidfile="$cidfile" --privileged -v "${PWD}:/src" "$name" /sbin/init --system
     cid=$(cat "$cidfile")
     rm -f "$cidfile"
-    docker exec --privileged "$cid" /bin/bash -e -c 'cd /src; ./scripts/ci-runner.sh build_tests'
-    # Wait a bit for the whole system to settle.
-    sleep 10s
-    docker exec --privileged "$cid" /bin/bash -e -c 'cd /src; ./scripts/ci-runner.sh run_tests'
+    # Wait for systemd to finish, then build and run tests.
+    docker exec --privileged "$cid" /bin/bash -e -c 'cd /src; ./scripts/ci-runner.sh wait_systemd build_tests run_tests'
     # Cleanup.
     docker kill "$cid"
 }
@@ -94,31 +92,47 @@ function license_check {
     fi
 }
 
-export GO15VENDOREXPERIMENT=1
-
-subcommand="$1"
-case "$subcommand" in
+while [ $# -gt 0 ]; do
+    case "$1" in
+    "wait_systemd" )
+	shift
+        echo "Waiting for systemd DBus socket..."
+	while [ ! -S /run/dbus/system_bus_socket ]; do
+	    sleep 0.2
+	done
+	echo "Waiting for systemd to finish startup..."
+	# Wait for systemd to finish startup.
+	systemctl is-system-running --wait || true
+	;;
     "build_source" )
+	shift
         echo "Building source..."
         build_source
         ;;
 
     "build_tests" )
+	shift
         echo "Building tests..."
         build_tests
         ;;
 
     "run_in_ct" )
 	shift
-	run_in_ct "$@"
+	IMAGE=$1
+	shift
+	GOVER=$1
+	shift
+	run_in_ct "$IMAGE" "$GOVER"
 	;;
 
     "run_tests" )
+	shift
         echo "Running tests..."
         run_tests
         ;;
 
     "license_check" )
+	shift
         echo "Checking licenses..."
         license_check
         ;;
@@ -127,4 +141,5 @@ case "$subcommand" in
         echo "Error: unrecognized subcommand (hint: try with 'run_tests')."
         exit 1
     ;;
-esac
+    esac
+done


### PR DESCRIPTION
The sleep stage, originally added by commit 07d38cb, is there to wait for systemd to finish its initialization stage (which includes wiping /tmp).

Commit 743c5ad added a step of building tests inside a container, and then commit 82dc44e moved the code into scripts/ci-runner.sh.

Now, sometimes building the tests fails with errors like this:

> github.com/coreos/go-systemd/v22/activation.test: open /tmp/go-build4063755751/b001/importcfg: no such file or directory

or

> asm: open $WORK/b006/symabis: no such file or directory

(as reported in https://github.com/coreos/go-systemd/pull/513 comments).

All this points to /tmp being wiped while the tests are being built.

Moving the sleep to before building tests (right after starting the container) should fix this. Yet better, let's use

	systemctl is-system-running --wait

to wait for systemd to settle.