### PR TITLE
sdjournal: Reduce allocations for common cases

### DIFF
--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -29,6 +29,34 @@ package sdjournal
 // #include <stdlib.h>
 // #include <syslog.h>
 //
+// struct my_gostring {
+//   char stack[64];
+//   char *heap;
+// };
+//
+// static inline char*
+// my_gostring_make(struct my_gostring *ms, _GoString_ s)
+// {
+//   char *ret;
+//   size_t n = _GoStringLen(s);
+//   if (n < sizeof(ms->stack)) {
+//     ms->heap = NULL;
+//     ret = ms->stack;
+//     memcpy(ret, _GoStringPtr(s), n);
+//     ret[n] = 0;
+//   } else {
+//     ret = strndup(_GoStringPtr(s), n);
+//     ms->heap = ret;
+//   }
+//   return ret;
+// }
+//
+// static inline void
+// my_gostring_clear(struct my_gostring *ms)
+// {
+//   free(ms->heap);
+// }
+//
 // int
 // my_sd_journal_open(void *f, sd_journal **ret, int flags)
 // {
@@ -75,12 +103,16 @@ package sdjournal
 // }
 //
 // int
-// my_sd_journal_add_match(void *f, sd_journal *j, const void *data, size_t size)
+// my_sd_journal_add_match(void *f, sd_journal *j, _GoString_ match)
 // {
+//   int r;
+//   struct my_gostring ms;
 //   int (*sd_journal_add_match)(sd_journal *, const void *, size_t);
 //
 //   sd_journal_add_match = f;
-//   return sd_journal_add_match(j, data, size);
+//   r = sd_journal_add_match(j, my_gostring_make(&ms, match), _GoStringLen(match));
+//   my_gostring_clear(&ms);
+//   return r;
 // }
 //
 // int
@@ -147,12 +179,16 @@ package sdjournal
 // }
 //
 // int
-// my_sd_journal_get_data(void *f, sd_journal *j, const char *field, const void **data, size_t *length)
+// my_sd_journal_get_data(void *f, sd_journal *j, _GoString_ field, const void **data, size_t *length)
 // {
+//   int r;
+//   struct my_gostring ms;
 //   int (*sd_journal_get_data)(sd_journal *, const char *, const void **, size_t *);
 //
 //   sd_journal_get_data = f;
-//   return sd_journal_get_data(j, field, data, length);
+//   r = sd_journal_get_data(j, my_gostring_make(&ms, field), data, length);
+//   my_gostring_clear(&ms);
+//   return r;
 // }
 //
 // int
@@ -174,12 +210,16 @@ package sdjournal
 // }
 //
 // int
-// my_sd_journal_test_cursor(void *f, sd_journal *j, const char *cursor)
+// my_sd_journal_test_cursor(void *f, sd_journal *j, _GoString_ cursor)
 // {
+//   int r;
+//   struct my_gostring ms;
 //   int (*sd_journal_test_cursor)(sd_journal *, const char *);
 //
 //   sd_journal_test_cursor = f;
-//   return sd_journal_test_cursor(j, cursor);
+//   r = sd_journal_test_cursor(j, my_gostring_make(&ms, cursor));
+//   my_gostring_clear(&ms);
+//   return r;
 // }
 //
 // int
@@ -218,14 +258,17 @@ package sdjournal
 //   return sd_journal_seek_tail(j);
 // }
 //
-//
 // int
-// my_sd_journal_seek_cursor(void *f, sd_journal *j, const char *cursor)
+// my_sd_journal_seek_cursor(void *f, sd_journal *j, _GoString_ cursor)
 // {
+//   int r;
+//   struct my_gostring ms;
 //   int (*sd_journal_seek_cursor)(sd_journal *, const char *);
 //
 //   sd_journal_seek_cursor = f;
-//   return sd_journal_seek_cursor(j, cursor);
+//   r = sd_journal_seek_cursor(j, my_gostring_make(&ms, cursor));
+//   my_gostring_clear(&ms);
+//   return r;
 // }
 //
 // int
@@ -265,12 +308,16 @@ package sdjournal
 // }
 //
 // int
-// my_sd_journal_query_unique(void *f, sd_journal *j, const char *field)
+// my_sd_journal_query_unique(void *f, sd_journal *j, _GoString_ field)
 // {
 //   int(*sd_journal_query_unique)(sd_journal *, const char *);
+//   struct my_gostring ms;
+//   char *tmp = my_gostring_make(&ms, field);
 //
 //   sd_journal_query_unique = f;
-//   return sd_journal_query_unique(j, field);
+//   int r = sd_journal_query_unique(j, tmp);
+//   my_gostring_clear(&ms);
+//   return r;
 // }
 //
 // int
@@ -505,11 +552,8 @@ func (j *Journal) AddMatch(match string) error {
 		return err
 	}
 
-	m := C.CString(match)
-	defer C.free(unsafe.Pointer(m))
-
 	j.mu.Lock()
-	r := C.my_sd_journal_add_match(sd_journal_add_match, j.cjournal, unsafe.Pointer(m), C.size_t(len(match)))
+	r := C.my_sd_journal_add_match(sd_journal_add_match, j.cjournal, match)
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -658,13 +702,10 @@ func (j *Journal) getData(field string) (*ptrsz, error) {
 		return nil, err
 	}
 
-	f := C.CString(field)
-	defer C.free(unsafe.Pointer(f))
-
 	ps := ptrszPool.Get().(*ptrsz)
 
 	j.mu.Lock()
-	r := C.my_sd_journal_get_data(sd_journal_get_data, j.cjournal, f, &ps.d, &ps.l)
+	r := C.my_sd_journal_get_data(sd_journal_get_data, j.cjournal, field, &ps.d, &ps.l)
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -927,11 +968,8 @@ func (j *Journal) TestCursor(cursor string) error {
 		return err
 	}
 
-	c := C.CString(cursor)
-	defer C.free(unsafe.Pointer(c))
-
 	j.mu.Lock()
-	r := C.my_sd_journal_test_cursor(sd_journal_test_cursor, j.cjournal, c)
+	r := C.my_sd_journal_test_cursor(sd_journal_test_cursor, j.cjournal, cursor)
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -1012,11 +1050,8 @@ func (j *Journal) SeekCursor(cursor string) error {
 		return err
 	}
 
-	c := C.CString(cursor)
-	defer C.free(unsafe.Pointer(c))
-
 	j.mu.Lock()
-	r := C.my_sd_journal_seek_cursor(sd_journal_seek_cursor, j.cjournal, c)
+	r := C.my_sd_journal_seek_cursor(sd_journal_seek_cursor, j.cjournal, cursor)
 	j.mu.Unlock()
 
 	if r < 0 {
@@ -1098,10 +1133,7 @@ func (j *Journal) GetUniqueValues(field string) ([]string, error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
-	f := C.CString(field)
-	defer C.free(unsafe.Pointer(f))
-
-	r := C.my_sd_journal_query_unique(sd_journal_query_unique, j.cjournal, f)
+	r := C.my_sd_journal_query_unique(sd_journal_query_unique, j.cjournal, field)
 
 	if r < 0 {
 		return nil, fmt.Errorf("failed to query journal: %w", syscall.Errno(-r))

--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -686,7 +686,8 @@ func (j *Journal) GetDataValue(field string) (string, error) {
 		return "", err
 	}
 
-	return strings.SplitN(val, "=", 2)[1], nil
+	_, v, _ := strings.Cut(val, "=")
+	return v, nil
 }
 
 // GetDataBytes gets the data object associated with a specific field from the
@@ -711,7 +712,8 @@ func (j *Journal) GetDataValueBytes(field string) ([]byte, error) {
 		return nil, err
 	}
 
-	return bytes.SplitN(val, []byte("="), 2)[1], nil
+	_, v, _ := bytes.Cut(val, []byte("="))
+	return v, nil
 }
 
 // GetEntry returns a full representation of the journal entry referenced by the
@@ -794,12 +796,13 @@ func (j *Journal) GetEntry() (*JournalEntry, error) {
 		}
 
 		msg := C.GoStringN((*C.char)(d), C.int(l))
-		kv := strings.SplitN(msg, "=", 2)
-		if len(kv) < 2 {
+
+		k, v, ok := strings.Cut(msg, "=")
+		if !ok {
 			return nil, errors.New("failed to parse field")
 		}
 
-		entry.Fields[kv[0]] = kv[1]
+		entry.Fields[k] = v
 	}
 
 	return entry, nil
@@ -1100,12 +1103,12 @@ func (j *Journal) GetUniqueValues(field string) ([]string, error) {
 		}
 
 		msg := C.GoStringN((*C.char)(d), C.int(l))
-		kv := strings.SplitN(msg, "=", 2)
-		if len(kv) < 2 {
+		_, v, ok := strings.Cut(msg, "=")
+		if !ok {
 			return nil, errors.New("failed to parse field")
 		}
 
-		result = append(result, kv[1])
+		result = append(result, v)
 	}
 
 	return result, nil

--- a/sdjournal/journal.go
+++ b/sdjournal/journal.go
@@ -641,39 +641,52 @@ func (j *Journal) PreviousSkip(skip uint64) (uint64, error) {
 	return uint64(r), nil
 }
 
-func (j *Journal) getData(field string) (unsafe.Pointer, C.int, error) {
+type ptrsz struct {
+	d unsafe.Pointer
+	l C.size_t
+}
+
+var ptrszPool = sync.Pool{
+	New: func() any {
+		return new(ptrsz)
+	},
+}
+
+func (j *Journal) getData(field string) (*ptrsz, error) {
 	sd_journal_get_data, err := getFunction("sd_journal_get_data")
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	f := C.CString(field)
 	defer C.free(unsafe.Pointer(f))
 
-	var d unsafe.Pointer
-	var l C.size_t
+	ps := ptrszPool.Get().(*ptrsz)
 
 	j.mu.Lock()
-	r := C.my_sd_journal_get_data(sd_journal_get_data, j.cjournal, f, &d, &l)
+	r := C.my_sd_journal_get_data(sd_journal_get_data, j.cjournal, f, &ps.d, &ps.l)
 	j.mu.Unlock()
 
 	if r < 0 {
-		return nil, 0, fmt.Errorf("failed to read message: %w", syscall.Errno(-r))
+		ptrszPool.Put(ps)
+		return nil, fmt.Errorf("failed to read message: %w", syscall.Errno(-r))
 	}
 
-	return d, C.int(l), nil
+	return ps, nil
 }
 
 // GetData gets the data object associated with a specific field from the
 // the journal entry referenced by the last completed Next/Previous function
 // call. To call GetData, you must have first called one of these functions.
 func (j *Journal) GetData(field string) (string, error) {
-	d, l, err := j.getData(field)
+	ps, err := j.getData(field)
 	if err != nil {
 		return "", err
 	}
 
-	return C.GoStringN((*C.char)(d), l), nil
+	s := C.GoStringN((*C.char)(ps.d), C.int(ps.l))
+	ptrszPool.Put(ps)
+	return s, nil
 }
 
 // GetDataValue gets the data object associated with a specific field from the
@@ -694,12 +707,14 @@ func (j *Journal) GetDataValue(field string) (string, error) {
 // journal entry referenced by the last completed Next/Previous function call.
 // To call GetDataBytes, you must first have called one of these functions.
 func (j *Journal) GetDataBytes(field string) ([]byte, error) {
-	d, l, err := j.getData(field)
+	ps, err := j.getData(field)
 	if err != nil {
 		return nil, err
 	}
 
-	return C.GoBytes(d, l), nil
+	b := C.GoBytes(ps.d, C.int(ps.l))
+	ptrszPool.Put(ps)
+	return b, nil
 }
 
 // GetDataValueBytes gets the data object associated with a specific field from the
@@ -746,6 +761,9 @@ func (j *Journal) GetEntry() (*JournalEntry, error) {
 		return nil, err
 	}
 
+	ps := ptrszPool.Get().(*ptrsz)
+	defer ptrszPool.Put(ps)
+
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
@@ -782,11 +800,9 @@ func (j *Journal) GetEntry() (*JournalEntry, error) {
 	entry.Cursor = C.GoString(c)
 
 	// Implements the JOURNAL_FOREACH_DATA_RETVAL macro from journal-internal.h
-	var d unsafe.Pointer
-	var l C.size_t
 	C.my_sd_journal_restart_data(sd_journal_restart_data, j.cjournal)
 	for {
-		r = C.my_sd_journal_enumerate_data(sd_journal_enumerate_data, j.cjournal, &d, &l)
+		r = C.my_sd_journal_enumerate_data(sd_journal_enumerate_data, j.cjournal, &ps.d, &ps.l)
 		if r == 0 {
 			break
 		}
@@ -795,7 +811,7 @@ func (j *Journal) GetEntry() (*JournalEntry, error) {
 			return nil, fmt.Errorf("failed to read message field: %w", syscall.Errno(-r))
 		}
 
-		msg := C.GoStringN((*C.char)(d), C.int(l))
+		msg := C.GoStringN((*C.char)(ps.d), C.int(ps.l))
 
 		k, v, ok := strings.Cut(msg, "=")
 		if !ok {
@@ -1076,6 +1092,9 @@ func (j *Journal) GetUniqueValues(field string) ([]string, error) {
 		return nil, err
 	}
 
+	ps := ptrszPool.Get().(*ptrsz)
+	defer ptrszPool.Put(ps)
+
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
@@ -1089,11 +1108,9 @@ func (j *Journal) GetUniqueValues(field string) ([]string, error) {
 	}
 
 	// Implements the SD_JOURNAL_FOREACH_UNIQUE macro from sd-journal.h
-	var d unsafe.Pointer
-	var l C.size_t
 	C.my_sd_journal_restart_unique(sd_journal_restart_unique, j.cjournal)
 	for {
-		r = C.my_sd_journal_enumerate_unique(sd_journal_enumerate_unique, j.cjournal, &d, &l)
+		r = C.my_sd_journal_enumerate_unique(sd_journal_enumerate_unique, j.cjournal, &ps.d, &ps.l)
 		if r == 0 {
 			break
 		}
@@ -1102,7 +1119,7 @@ func (j *Journal) GetUniqueValues(field string) ([]string, error) {
 			return nil, fmt.Errorf("failed to read message field: %w", syscall.Errno(-r))
 		}
 
-		msg := C.GoStringN((*C.char)(d), C.int(l))
+		msg := C.GoStringN((*C.char)(ps.d), C.int(ps.l))
 		_, v, ok := strings.Cut(msg, "=")
 		if !ok {
 			return nil, errors.New("failed to parse field")


### PR DESCRIPTION
For comparison, with `Journal.GetDataValue`, these changes reduce the allocs per call from 5 to 1.

