### PR TITLE
dbus: lock subscriber mutexes when dispatch reads updateCh

### DIFF
--- a/dbus/subscription.go
+++ b/dbus/subscription.go
@@ -62,10 +62,16 @@ func (c *Conn) dispatch() {
 				c.jobComplete(signal)
 			}
 
+			c.subStateSubscriber.Lock()
+			c.propertiesSubscriber.Lock()
 			if c.subStateSubscriber.updateCh == nil &&
 				c.propertiesSubscriber.updateCh == nil {
+				c.propertiesSubscriber.Unlock()
+				c.subStateSubscriber.Unlock()
 				continue
 			}
+			c.propertiesSubscriber.Unlock()
+			c.subStateSubscriber.Unlock()
 
 			var unitPath dbus.ObjectPath
 			switch signal.Name {


### PR DESCRIPTION
Closes #519

`Conn.dispatch` at dbus/subscription.go:65-66 read
`c.subStateSubscriber.updateCh` and `c.propertiesSubscriber.updateCh`
without holding the corresponding mutexes, while
`SetSubStateSubscriber` writes those fields under
`subStateSubscriber.Lock()`. Issue #519 includes a `go run -race`
reproducer that reliably fires the race detector.

Wrap the early-out check with the locks so the read is protected:
`subStateSubscriber.Lock()` then `propertiesSubscriber.Lock()`, then
test, then unlock in reverse order. The diff is exactly the one
suggested in the issue. The subsequent signal routing (`sendPropertiesUpdate`,
`sendSubStateUpdate`) already takes the same locks internally, so no
additional locking is needed there.

Verified locally:

  gofmt -d dbus/subscription.go   # no diff
  go vet ./dbus/...                # clean
  go build ./dbus/...              # clean

Disclosed assistance: this PR was authored with the assistance of an
AI coding assistant (Claude Code, Anthropic) operating under the
maintainer's direct supervision. The change is a six-line mutex
guard; no behaviour is changed in the no-race path.